### PR TITLE
Added the subset of original data for quoref that was used for perturbations

### DIFF
--- a/quoref/README.md
+++ b/quoref/README.md
@@ -2,7 +2,7 @@
 
 The json file contains the contrast sets built on top of the official [Quoref](https://allennlp.org/quoref) test set.
 
-```quoref_test_perturbations_20191206_merged.json``` contains the set of perturbed instances. Each instance is based on an instance in the test set, and the original instance can be identified using the ````original_id``` field in this file.
+```quoref_test_perturbations_20191206_merged.json``` contains the set of perturbed instances. Each instance is based on an instance in the test set, and the original instance can be identified using the ```original_id``` field in this file.
 
 ```quoref_original_subset_20191206_merged.json``` is the subset of questions from the test set that the perturbations are based on. So instance in the perturbed instances file should have a corresponding instance in this file, such that the ```original_id``` there should be the same as the ```id``` here.
 

--- a/quoref/README.md
+++ b/quoref/README.md
@@ -2,6 +2,10 @@
 
 The json file contains the contrast sets built on top of the official [Quoref](https://allennlp.org/quoref) test set.
 
+```quoref_test_perturbations_20191206_merged.json``` contains the set of perturbed instances. Each instance is based on an instance in the test set, and the original instance can be identified using the ````original_id``` field in this file.
+
+```quoref_original_subset_20191206_merged.json``` is the subset of questions from the test set that the perturbations are based on. So instance in the perturbed instances file should have a corresponding instance in this file, such that the ```original_id``` there should be the same as the ```id``` here.
+
 ## Scripts
 
 ### Minimal command line interface for manual perturbation

--- a/quoref/quoref_original_subset_20191206_merged.json
+++ b/quoref/quoref_original_subset_20191206_merged.json
@@ -1,0 +1,5832 @@
+{
+  "data": [
+    {
+      "title": "Let's Live a Little",
+      "url": "https://en.wikipedia.org/wiki/Let%27s_Live_a_Little",
+      "paragraphs": [
+        {
+          "context": "At Montgomery Advertising in New York City, Duke Crawford is having trouble handling the account of cosmetics manufacturer Michele Bennett, one of the company's most important clients\u2014and his former fianc\u00e9e. Still determined to win him back, Michele refuses to sign a contract until Duke reciprocates her affection. When Duke threatens to quit Michele's account, his boss James Montgomery assigns him to do the book promotion for a new client, a nerve psychologist named J.O. Loring.\nWhile taking a taxi to the psychologist's office, Duke shaves with an electric razor he invented, but his nervousness and stress result in leaving half his mustache intact. When he arrives at the client's office, Duke discovers that J.O. Loring is in fact an attractive woman named Jo. Staring at the half a mustache, Jo mistakes him for one of her mentally disturbed patients. Determines to prove to himself that he is anesthetized from women, he kisses the doctor. Jo reacts by recommending that he read her book on stress relief titled Let's Live a Little. Later that night, Duke is unable to fall asleep.\nThe next morning, after Duke makes an appointment to see Jo as her patient, Jo advises him that if he wants his former fianc\u00e9e to sign the contract, he must wine and dine her. Following her advice, Duke arranges a date with Michele at a nightclub. Wanting to observe the encounter for scientific reasons, Jo arrives at the nightclub with her stuffy surgeon boyfriend, Dr. Richard Field. When Michele notices that Duke and Jo are falling in love, and when she is served a cake with an advertising contract inside instead of a marriage license, she throws his drink at him and storms out of the nightclub. Duke is reduced to a nerve-wracked state\u2014repeating ad slogans over and over.",
+          "context_id": "d55b153782dc569aa5c2fd6bec3ba80f3713228f",
+          "qas": [
+            {
+              "question": "To whose office is Duke traveling when he shaves off half of his mustache?",
+              "id": "bd22d78f040a9b23068fdb9abb160529ec0c3883",
+              "answers": [
+                {
+                  "text": "J.O. Loring",
+                  "answer_start": 471
+                }
+              ]
+            },
+            {
+              "question": "What kind of doctor does Duke kiss?",
+              "id": "c17594a3bc06fdd1a8ba5f31f0421777d959052d",
+              "answers": [
+                {
+                  "text": "nerve psychologist",
+                  "answer_start": 446
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person Michele wants to win back?",
+              "id": "874c401ad5dc0aef29997307859b23c5bf8f20ff",
+              "answers": [
+                {
+                  "text": "Duke Crawford",
+                  "answer_start": 44
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person who invented an electric razor?",
+              "id": "9c0428d80f37febfae0a1cf92676a1751fa58b17",
+              "answers": [
+                {
+                  "text": "Duke Crawford",
+                  "answer_start": 44
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person of the person who mistakes Duke for one of her mentally disturbed patients?",
+              "id": "228050c64d5c4f6b540c62de9b3765981982233f",
+              "answers": [
+                {
+                  "text": "J.O. Loring",
+                  "answer_start": 717
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person Jo recommends that Duke must wine and dine?",
+              "id": "435b9b0bb19802ca2cb98360806a741bb3c42189",
+              "answers": [
+                {
+                  "text": "Michele Bennett",
+                  "answer_start": 123
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Cavalcade (1933 film)",
+      "url": "https://en.wikipedia.org/wiki/Cavalcade_(1933_film)",
+      "paragraphs": [
+        {
+          "context": "On the last day of 1899, Jane and Robert Marryot, an upper-class couple, return to their townhouse in a fashionable area of London before midnight, so they can keep their tradition of celebrating the new year with a midnight toast. Although Jane and Robert have been married for some years and have two young sons, Edward and Joey, they are still very much in love. Jane worries because Robert has joined the City of London Imperial Volunteers as an officer, and will soon be leaving to serve in the Second Boer War, where Jane's brother is already fighting in the Siege of Mafeking. Downstairs, the Marryots' butler Alfred Bridges mixes punch for their toast, while Cook dons her finest outfit to attend the public outdoor celebrations. Alfred has joined the CIV as a private and is also leaving soon. His wife Ellen, the Marryots' maid, worries about what will become of her and their new baby Fanny if Alfred is killed or seriously injured, but he is confident despite the pessimistic predictions of Ellen's elderly mother, Mrs. Snapper. At midnight, the Marryot and Bridges families ring in the new century while Cook dances with other revelers in the street.\nShortly thereafter, Jane bids an emotional farewell to Robert at the dock when he boards the troop ship bound for Africa, while Ellen tearfully sees off Alfred, who is leaving on the same ship. While Robert is away, Jane's friend Margaret Harris keeps her company and gives her emotional support. Margaret's young daughter Edith plays Boer War games with Edward and Joey Marryot using toy soldiers and cannons, which distresses Jane. While Jane and Margaret are attending a comic operetta at the theatre to take Jane's mind off the war, the relief of Mafeking is announced from the stage, and the audience cheers. Robert and Alfred soon return home unharmed, to the delight of their families, and Robert is knighted for his service.",
+          "context_id": "538e9739bb5346e181780328e6f9781ed6dc4bcb",
+          "qas": [
+            {
+              "question": "What are the first names of the three people who play Boer War games together?",
+              "id": "f7511c8a3f596915572afd684bbbf4bad3593ff6",
+              "answers": [
+                {
+                  "text": "Edith",
+                  "answer_start": 1487
+                },
+                {
+                  "text": "Edward",
+                  "answer_start": 1519
+                },
+                {
+                  "text": "Joey",
+                  "answer_start": 1530
+                }
+              ]
+            },
+            {
+              "question": "What are the last names of the two men who are boarding a ship bound for Africa?",
+              "id": "7a11431151f7d7f4cd31c1698760c7874d7d44cb",
+              "answers": [
+                {
+                  "text": "Marryot",
+                  "answer_start": 41
+                },
+                {
+                  "text": "Bridges",
+                  "answer_start": 624
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the CIV?",
+              "id": "24fb7b717d6cfe799a528597cd205efb6a8fcd5c",
+              "answers": [
+                {
+                  "text": "City of London Imperial Volunteers",
+                  "answer_start": 409
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Manzanar",
+      "url": "https://en.wikipedia.org/wiki/Manzanar",
+      "paragraphs": [
+        {
+          "context": "Manzanar was first inhabited by Native Americans nearly 10,000 years ago. Approximately 1,500 years ago, the area was settled by the Owens Valley Paiute, who ranged across the Owens Valley from Long Valley on the north to Owens Lake on the south, and from the crest of the Sierra Nevada on the west to the Inyo Mountains on the east. Other Native American nations in the region included the Miwok, Western Mono, and Tubatulabal to the west, the Shoshone to the south and east, and the Mono Lake Paiute to the north. The Owens Valley Paiute hunted and fished, collected pine nuts, and raised crops utilizing irrigation in the Manzanar area. They also traded brown-ware pottery for salt from the Saline Valley, and traded other wares and goods across the Sierra Nevada during the summer and fall.The Owens Valley had received scant attention from European Americans before the early 1860s, as it was little more than a crossroads of the routes through the area. When gold and silver were discovered in the Sierra Nevada and the Inyo Mountains, the resulting sudden influx of miners, farmers, cattlemen and their hungry herds brought conflict with the Owens Valley Paiute, whose crops were being destroyed. The Owens Valley Indian War of 1861\u20131863 ensued; at the end, the Owens Valley Paiute, along with other native peoples in the region, were forced at gunpoint by the United States Army to walk almost 200 miles (320 km) to Fort Tejon, in one of the many forced relocations or \"Trails of Tears\" inflicted upon Native Americans in the United States.In this Trail of Tears, the U.S. Army was intentionally brutal.\n\"The Army didn't take them on a direct route, either, said Owens Valley Paiute elder Irene Button. \"They were forced to walk all the way around the eastern shore of Owens Lake (covers an area of approximately 108 square miles (280 km2)). They wanted to make sure that as many as possible would die before they reached Fort Tejon.\"Approximately one-third of the Native Americans in the Owens Valley were forcibly relocated to Fort Tejon. After 1863, many returned to their permanent villages that had been established along creeks flowing down from the Sierra Nevada mountains. In the Manzanar area, the Owens Valley Paiute had established villages along Bairs, Georges, Shepherds, and Symmes creeks. Evidence of Paiute settlement in the area is still present.",
+          "context_id": "7e69b0c325e476766b88c239513e204fa22d8d0b",
+          "qas": [
+            {
+              "question": "What mountain range did the creeks flow from when the Indians returned to their villages in 1863?",
+              "id": "d06a5a4be4de55d9bb21d7494c97a2f3c42f3bed",
+              "answers": [
+                {
+                  "text": "Sierra Nevada",
+                  "answer_start": 2164
+                }
+              ]
+            },
+            {
+              "question": "What is the term that is used as the name of the forced march for the tribes in the Owens valley?",
+              "id": "47fe28e50b252df075e70cdba247ab3fff176bc7",
+              "answers": [
+                {
+                  "text": "Trails of Tears",
+                  "answer_start": 1478
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "After the December 7, 1941, attack on Pearl Harbor, the United States Government swiftly moved to begin solving the \"Japanese Problem\" on the West Coast of the United States. In the evening hours of that same day, the Federal Bureau of Investigation (FBI) arrested selected \"enemy\" aliens, including more than 5,500 Issei men. The California government pressed for action by the national government, as many citizens were alarmed about potential activities by people of Japanese descent.\nOn February 19, 1942, President Franklin D. Roosevelt signed Executive Order 9066, which authorized the Secretary of War to designate military commanders to prescribe military areas and to exclude \"any or all persons\" from such areas. The order also authorized the construction of what would later be called \"relocation centers\" by the War Relocation Authority (WRA) to house those who were to be excluded. This order resulted in the forced relocation of over 120,000 Japanese Americans, two-thirds of whom were native-born American citizens. The rest had been prevented from becoming citizens by federal law. Over 110,000 were incarcerated in the ten concentration camps located far inland and away from the coast.Manzanar was the first of the ten concentration camps to be established. Initially, it was a temporary \"reception center\", known as the Owens Valley Reception Center from March 21, 1942, to May 31, 1942. At that time, it was operated by the US Army's Wartime Civilian Control Administration (WCCA).The Owens Valley Reception Center was transferred to the WRA on June 1, 1942, and officially became the \"Manzanar War Relocation Center.\" The first Japanese American incarcerees to arrive at Manzanar were volunteers who helped build the camp. By mid\u2013April, up to 1,000 Japanese Americans were arriving daily, and by July, the population of the camp neared 10,000. Over 90 percent of the incarcerees were from the Los Angeles area, with the rest coming from Stockton, California; and Bainbridge Island, Washington. Many were farmers and fishermen. Manzanar held 10,046 incarcerees at its peak, and a total of 11,070 people were incarcerated there.",
+          "context_id": "bce516ce31e2507f0439968b19ed56574d8c492b",
+          "qas": [
+            {
+              "question": "What order authorized the construction of what would later be called \"relocation centers\"?",
+              "id": "dda7c1984db53d1a4647c3828138d375b2a227f4",
+              "answers": [
+                {
+                  "text": "Executive Order 9066",
+                  "answer_start": 549
+                }
+              ]
+            },
+            {
+              "question": "What order resulted in forced relocation of over 120,000 Japanese Americans?",
+              "id": "513e7a697f098281d5b7f0357331ae3ad2f9d0e7",
+              "answers": [
+                {
+                  "text": "Executive Order 9066",
+                  "answer_start": 549
+                }
+              ]
+            },
+            {
+              "question": "What was the name of the place from March 21 1942 to May 31, 1942 that had incarcerees from Stockton California and Bainbridge Island?",
+              "id": "6a5ae1d1c7bc0f3ae6a668d1ee320b823022e0dc",
+              "answers": [
+                {
+                  "text": "Owens Valley Reception Center",
+                  "answer_start": 1505
+                }
+              ]
+            },
+            {
+              "question": "What was the name of the place from March 21 1942 to May 31, 1942 that had most of its incarcerees made up of farmers and fishermen?",
+              "id": "ab0582d52f448f839fe0f8050d916279fa52283d",
+              "answers": [
+                {
+                  "text": "Owens Valley Reception Center",
+                  "answer_start": 1505
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Frederick Douglass and the White Negro",
+      "url": "https://en.wikipedia.org/wiki/Frederick_Douglass_and_the_White_Negro",
+      "paragraphs": [
+        {
+          "context": "The film follows Douglass' life from slavery as a young man through to his time in Ireland where he befriended Daniel O'Connell, toured the country spreading the message of abolition and was treated as a human being for the first time by white people. His arrival in Ireland coincided with the Great Famine and he witnessed white people in what he considered to be a worse state than his fellow African Americans back in the US. The film follows Douglass back to America where he buys his freedom with funds raised in Ireland and Britain. Fellow passengers on his return journey include the Irish escaping the famine who arrive in their millions and would go on to play a major role in the New York Draft Riot of 1863 which Douglass could only despair over. The film examines (with contributions from the author of How The Irish Became White Noel Ignatiev amongst others) the turbulent relationship between African Americans and Irish Americans during the American Civil War, what drew them together and what drove them apart and how this would shape the America of the twentieth century and beyond.",
+          "context_id": "51e057b1c095a2d033c819b93344b791d829758b",
+          "qas": [
+            {
+              "question": "Who witnessed the plight of the white people in Ireland?",
+              "id": "42fda7873bb7185d625b27acd922ce706f305c90",
+              "answers": [
+                {
+                  "text": "Douglass",
+                  "answer_start": 17
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Trick Baby",
+      "url": "https://en.wikipedia.org/wiki/Trick_Baby",
+      "paragraphs": [
+        {
+          "context": "\"Blue\" Howard and \"White Folks\" (Kiel Martin) are two con men in Philadelphia. Blue is an older black hustler who raised White Folks and taught him \"the con\". White Folks is the son of a black mother who is a prostitute and a white father. \"White Folks\" complexion is light enough for him to pass as a white man which gives him an advantage in the con. The duo exploit the dynamics between whites and blacks to achieve their cons. \"Blue\" usually plays a vulnerable black man being exploited by \"White Folks\" which allows Folks to gain the credibility needed to pull off the con. In a 1973 review in the New York Times, Roger Greenspun wrote \"Trick Baby seems most interesting in its understanding of race relations\u2026relations between Folks and Blue are absolutely normal, not very competitive, resilient, and rich in a kind of mutual professional appreciation.\" While Folks' skin color has various implications in society and is crucial to the con that the pair runs. It does not impact the relationship between Blue and Folks.  Due to Folks' ability to pass, the pair pull off the biggest score of their lives. Before they can collect the money, a previous con complicates things. Unbeknownst to them their previous victim had mob ties and now they have run afoul of the Mafia and a corrupt cop. They must decide whether to leave town or risk their lives to collect the $130,000 from their most brilliant con.",
+          "context_id": "85559dce31a5e428c5510c2302d15cc4997e785f",
+          "qas": [
+            {
+              "question": "What are the aliases of the people who exploit the dynamics between blacks and whites? ",
+              "id": "45ec91044416fc93a3db33aef9de77dbe32a198f",
+              "answers": [
+                {
+                  "text": "Blue",
+                  "answer_start": 1
+                },
+                {
+                  "text": "White Folks",
+                  "answer_start": 19
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person White Folks usually exploits in the con?",
+              "id": "5333a9f22a77f10db44d1a563c0f13ef0ffc376a",
+              "answers": [
+                {
+                  "text": "Howard",
+                  "answer_start": 7
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Friday the 13th: A New Beginning",
+      "url": "https://en.wikipedia.org/wiki/Friday_the_13th:_A_New_Beginning",
+      "paragraphs": [
+        {
+          "context": "Five years after the demise of mass murderer Jason Voorhees, the youngest survivor Tommy Jarvis awakens from a nightmare of him witnessing two grave robbers digging up Jason Voorhees's body. Jason rises from the grave and murders the grave robbers before advancing towards Tommy. Upon arriving at Pinehurst Halfway House, a secluded residential treatment facility, Tommy is introduced to director Pam Roberts and Dr. Matt Letter. In his assigned room, Tommy also meets Reggie, a boy whose grandfather, George, works as the kitchen cook. Other teens introduced are redhead Robin, Goth Violet, shy Jake, short-tempered Vic, and compulsive eater Joey. The sheriff brings in two more residents, lovers Eddie and Tina, after catching them having sex on neighbor Ethel Hubbard's lawn. Ethel Hubbard and her son Junior show up and threaten to have the house closed down if the teens do not stop sneaking onto their property.\nLater that day, Vic snaps and kills Joey with an axe, and is subsequently arrested. The body is discovered by attending ambulance drivers Roy Burns and Duke. Roy is deeply disturbed by Joey's death, but Duke believes that the murder was a prank gone horribly wrong. That evening, greasers Vinnie and Pete are murdered by an unseen assailant after their car breaks down. The following night, Billy and his girlfriend Lana are killed with an axe. Panic begins to ensue, but the mayor refuses to believe the sheriff's claim that, somehow, Jason Voorhees has returned.",
+          "context_id": "7382bd4da57d67ed6fa413e36bd665736d767e0d",
+          "qas": [
+            {
+              "question": "What's the full name of the man who works with the man who thinks Joey's murder was a prank gone wrong?",
+              "id": "edec3c1f5b471cc57f2d6025f4fa3b1a03e89f26",
+              "answers": [
+                {
+                  "text": "Roy Burns",
+                  "answer_start": 1056
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Queen (1968 film)",
+      "url": "https://en.wikipedia.org/wiki/The_Queen_(1968_film)",
+      "paragraphs": [
+        {
+          "context": "Jack, a 24 year old gay man living in New York and working as a drag queen named 'Sabrina', is the mistress of ceremonies for the Miss All-America Camp Beauty Contest. The contest operates on a points system - a maximum of five points each for walk, talk, bathing suit, gown, make-up and hair-do, and ten points for beauty. \nJack's prot\u00e9g\u00e9, Richard, performs under the name 'Harlow' and has entered the contest. Also competing is Crystal LaBeija (founder of the House of Labeija, of which Pepper LaBeija was a member and later the mother). Harlow and Crystal both make it into the top five, with each finalist completing a final runway walk into the audience. Crystal places fourth, to her displeasure, and storms off the stage. Harlow is crowned as the winner.\nAs the contests begin to pack up, Crystal and another contestant are shown exclaiming to the camera why Harlow should not have won. Crystal states that the contest was fixed, that she may sue Sabrina, and that she knows she is beautiful despite not winning. As they begin to leave the building, Crystal runs into Harlow and Sabrina on the stairs where Sabrina denies the allegations. The film closes on Harlow out of drag, walking through a subway station and twirling his crown on one hand.\nIn between rehearsing and performing, the contestants discuss topics of the time such as draft boards, sexual identity and sex-change operations, and being a drag queen. One contestant recounts receiving a draft notice and being turned away because of his feminine appearance, despite writing a letter to the government requesting to serve so he could protect his country.",
+          "context_id": "7d59c6dca06e91cfd6f13ffd266c61ef28f5eb74",
+          "qas": [
+            {
+              "question": "What is the first name of the person who may sue Jack?",
+              "id": "e257fc2c9e773d9b7d0e8f25c67c047c5a357894",
+              "answers": [
+                {
+                  "text": "Crystal",
+                  "answer_start": 894
+                }
+              ]
+            },
+            {
+              "question": "What is the real name of the person who walks through a subway station?",
+              "id": "a9e1fd1d1bc75be77a2265408141fabfc8bb3ba1",
+              "answers": [
+                {
+                  "text": "Richard",
+                  "answer_start": 341
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "I Cover the Waterfront",
+      "url": "https://en.wikipedia.org/wiki/I_Cover_the_Waterfront",
+      "paragraphs": [
+        {
+          "context": "San Diego Standard reporter H. Joseph Miller has been covering the city's waterfront for the past five years and is fed up with the work. He longs to escape the waterfront life and land a newspaper job back East so he can marry his Vermont sweetheart. Miller is frustrated by the lack of progress of his current assignment investigating the smuggling of Chinese people into the country by a fisherman named Eli Kirk. One morning after wasting a night tracking down bad leads, his editor at the Standard orders him to investigate a report of a girl swimming naked at the beach. There he meets Julie Kirk, the daughter of the man he's been investigating.\nMeanwhile, Eli Kirk and his crew are returning to San Diego with a Chinese passenger when the Coast Guard approaches. Not wanting to be caught with evidence of his smuggling operation, Kirk orders his men to weigh down the Chinaman and lower him overboard to his death. The Coast Guard, accompanied by Miller, board the boat but find nothing. The next day, Miller discovers the Chinaman's body which was carried in with the tide, and takes it as evidence to his editor, who still remains skeptical of Kirk's guilt. To get conclusive evidence, Miller tells him he plans to romance Kirk's daughter Julie in order to break the smuggling operation.",
+          "context_id": "6e89f5e93e28c94b06ad6aaac9eb6b2444664d1f",
+          "qas": [
+            {
+              "question": "What is the full name of the character who takes the body of a deceased Chinaman to his boss?",
+              "id": "e54f1df43bd69fc6cb17c320e9be9f29a85b90ce",
+              "answers": [
+                {
+                  "text": "H. Joseph Miller",
+                  "answer_start": 28
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the character who meets Julie Kirk at the beach?",
+              "id": "1548b6837839631eec4bc11244701be109325d8e",
+              "answers": [
+                {
+                  "text": "H. Joseph Miller",
+                  "answer_start": 28
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Jane Joseph",
+      "url": "https://en.wikipedia.org/wiki/Jane_Joseph",
+      "paragraphs": [
+        {
+          "context": "Jane Marian Joseph (31 May 1894 \u2013 9 March 1929) was an English composer, arranger and music teacher. She was a pupil and later associate of the composer Gustav Holst, and was instrumental in the organisation and management of various of the music festivals which Holst sponsored. Many of her works were composed for performance at these festivals and similar occasions. Her early death at age 35, which prevented the full realisation of her talents, was considered by her contemporaries as a considerable loss to English music.\nHolst first observed Joseph's potential when he was teaching her composition at St Paul's Girls' School. She began to act as his amanuensis in 1914, when he was composing The Planets, her special responsibility being the preparation of the score for the \"Neptune\" movement. She continued to assist Holst with transcriptions, arrangements and translations, and was his librettist for the choral ballet The Golden Goose.\nDuring her short professional life she became an active member of the Society of Women Musicians, was the prime mover behind the first Kensington Musical Competition Festival, and helped to found the Kensington Choral Society.  She also taught music at a girls' school, where Holst's daughter Imogen was one of her pupils, and became a leading figure in the musical life of Morley College. Two memorial prizes and scholarships were endowed in her name.\nMost of Joseph's compositions were never published and are now considered lost. Of her published works, two early short orchestral pieces, Morris Dance and Bergamask won considerable critical praise, although neither became part of the general orchestral repertory.  Two choral works, A Festival Venite and A Hymn for Whitsuntide were admired during her lifetime, but never commercially recorded. Since her death, her work has seldom been performed, but occasionally been broadcast.  Her carol \"A Little Childe There is Ibore\" was thought by Holst to be among the best of its kind.",
+          "context_id": "5f34135887ffdbbb737d30c8bc6fd07aeaae803d",
+          "qas": [
+            {
+              "question": "What is the full name of the person who was a pupil and later associate of the composer whose music festivals she was also instrumental in organizing and managing? ",
+              "id": "3b8e8c91a05d6cca8fff123d38ea080cd0ea70b6",
+              "answers": [
+                {
+                  "text": "Jane Marian Joseph",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person whose early death was considered by her contemporaries as a considerable loss to English music?",
+              "id": "ff9a659951af920d8dbcce754570cc0b6616c3c4",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 549
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person as whose amanuensis Joseph began to act in 1914?",
+              "id": "78d63b72ce72fefabd67585d232f644ff1849eb3",
+              "answers": [
+                {
+                  "text": "Holst",
+                  "answer_start": 528
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who was composing The Planets in 1914?",
+              "id": "1990ddb7bf73014233f88a811f294969b2c51d9b",
+              "answers": [
+                {
+                  "text": "Holst",
+                  "answer_start": 528
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who was the librettist for the choral ballet The Golden Goose?",
+              "id": "a5b6aa7e7f802852ad1b29d97b4903cb32773e0f",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 549
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who became an active member of the Society of Women Musicians during her short professional life?",
+              "id": "97cc224e0688e43b8d02a2ad1b5052d9fbe1fc77",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 549
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who helped to found the Kensington Choral Society?",
+              "id": "354ec540917086193ae38bde68581d3831a9d3c4",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 549
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who became a leading figure in the musical life of Morley College?",
+              "id": "c05e93eb142f8d74973cd26312c56a53d6a26958",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 549
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who taught music at a girls' school, where Imogen was one of her pupils?",
+              "id": "6484c1eca89c2a3342be98577db2189e9f0179d4",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 549
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person whose published works included two early short orchestral pieces, Morris Dance and Bergamask, which won considerable critical praise?",
+              "id": "04dd6db6e1bcdfe93afe6fb2ca0fabe7ae51f505",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 1408
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person during whose lifetime two choral works, A Festival Venite and A Hymn for Whitsuntide, were admired but never commercially recorded?",
+              "id": "712613061c959db6cdd61e99bcb5523d1dc35548",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 1408
+                }
+              ]
+            },
+            {
+              "question": "What was the last name of Holst's pupil?",
+              "id": "d521eb098d62f5b93e6878a8fc0ed075f40b7e76",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 12
+                }
+              ]
+            },
+            {
+              "question": "What was the first name of the person who assisted Holst with transcriptions?",
+              "id": "e2193cfe0569ccd4fca6ee5e355e802740d97ab5",
+              "answers": [
+                {
+                  "text": "Jane",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What were names of Joseph's two published works won considerable critical praise?",
+              "id": "a901fac5f8f58042245fc07b4d2637b616f0c0c0",
+              "answers": [
+                {
+                  "text": "Morris Dance",
+                  "answer_start": 1539
+                },
+                {
+                  "text": "Bergamask",
+                  "answer_start": 1556
+                }
+              ]
+            },
+            {
+              "question": "What were the names of the two choral works that were never commercially recorded?",
+              "id": "4c6d597fcfa964f2e91a0b708ab694b9b52f4e4a",
+              "answers": [
+                {
+                  "text": "A Festival Venite",
+                  "answer_start": 1685
+                },
+                {
+                  "text": "A Hymn for Whitsuntide",
+                  "answer_start": 1707
+                }
+              ]
+            },
+            {
+              "question": "What was the name of Joseph's carol that Holst thought was the best of its kind?",
+              "id": "ff508bd9bd9d33942bb3a437bea2b98264f20bef",
+              "answers": [
+                {
+                  "text": "A Little Childe There is Ibore",
+                  "answer_start": 1895
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person that attended St. Paul's Girls School?",
+              "id": "90e3d7fabb04e620975b765c3744cbfe0deaac22",
+              "answers": [
+                {
+                  "text": "Jane Marian Joseph",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What was the last name of the person who was instrumental in the organization and management of various music festivals which Holst sponsored?",
+              "id": "0acc0aec80416722d26a14883b95f62d65cef296",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 12
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "In 1909 Joseph won a scholarship to St Paul's Girls' School (SPGS) in Hammersmith. The school had opened in 1904, as an offshoot of the long-established St Paul's School for boys. Its high mistress, Frances Ralph Gray, was a formidable figure with traditional views about female education, who nevertheless provided a lively and varied learning environment in which Joseph excelled.  Apart from her academic successes, Joseph played double-bass in the school orchestra, gave an acclaimed piano performance of Bach's D minor keyboard concerto, began to compose, and won a prize for sight-reading. While at the school she composed \"The Carrion Crow\", a song setting which, in 1914, became her first published work. Outside music she supported the school's Literary Society, where she presented papers on Charlotte Bront\u00eb and Samuel Taylor Coleridge. She also won Honours in the examinations of the Royal Drawing Society.\nAmong the music teachers at SPGS, most significantly in terms of her musical development, Joseph encountered the emergent composer Gustav Holst, then little known, who taught her composition. After leaving the Royal College of Music in 1898 Holst had earned his living as an organist, and as a trombonist in various orchestras, while awaiting critical recognition as a composer. In 1903 he gave up his orchestral appointments to concentrate on composing, but found that he needed a regular income. He became a music teacher, initially at the James Allen's Girls' School in Dulwich; in 1905 he was recommended to Frances Gray by Adine O'Neill, a former pupil of Clara Schumann, who taught piano at SPGS. He was first appointed on a part-time basis to teach singing, and later extended his activities to cover the school's wider music curriculum including conducting and composition. According to the composer Alan Gibbs, Joseph quickly came under Holst's spell, and adopted his principles as her own. Holst later described her as the best girl pupil he ever had: \"From the first she showed an individual attitude of mind and an eagerness to absorb all that was beautiful\".",
+          "context_id": "53e8d378c7414e53d10d3126ef7e6d66c0a01b77",
+          "qas": [
+            {
+              "question": "What is the full name of the school whose high mistress was a formidable figure with traditional views about female education?",
+              "id": "dc19699c5d7d70e35d89ab9c83bb937416a567c1",
+              "answers": [
+                {
+                  "text": "St Paul's Girls' School",
+                  "answer_start": 36
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who composed \"The Carrion Crow\" while at SPGS?",
+              "id": "cb5447eabba857aefd43f975418694ff2b45befc",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 419
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who presented papers on Charlotte Bront\u00eb and Samuel Taylor Coleridge at the school's Literary Society?",
+              "id": "eee573a81ee85674381511f1e525ab1e5fe03e0a",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 419
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who won Honours in the examinations of the Royal Drawing Society?",
+              "id": "96e3c4b500f4c9e28facac8dadb493399fb9a7fd",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 419
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who became a music teacher, initially at the James Allen's Girls' School in Dulwich? ",
+              "id": "2bd35d035704667352a739bfd447fad74c035855",
+              "answers": [
+                {
+                  "text": "Holst",
+                  "answer_start": 1160
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who was recommended to Frances Gray by Adine O'Neill?",
+              "id": "6270e52eac4ebcdaf47fa8c9c7b3fd1987bb4905",
+              "answers": [
+                {
+                  "text": "Holst",
+                  "answer_start": 1160
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who was first appointed on a part-time basis at St Paul's Girls' School to teach singing?",
+              "id": "da4029f48014eabbf4fddb88a182956ae9ccbbb4",
+              "answers": [
+                {
+                  "text": "Holst",
+                  "answer_start": 1160
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "When Joseph left Girton, the First World War was at a critical state; the Battle of the Somme had begun on 1 July 1916. Joseph wanted to assist the war effort, and after considering work on the land or in a munitions factory, took up part-time welfare work in Islington. In the autumn of 1916 she began teaching at Eothen, a small private school for girls in Caterham, founded and run by the Misses Catharine and Winifred Pye. In 1917 Holst's ten-year-old daughter Imogen started at the school; soon, under Joseph's guidance the young pupil was composing her own music. Joseph extended her own musical activities by joining the orchestra at Morley College, where Holst was the director of music and where her brother Edwin had played the cello before the war. At first she played the double-bass, but later took French horn lessons, possibly from Adolph Borsdorf; later still, at very short notice, she taught herself the timpani part for a summer concert. By 1918 she was a member of the Morley committee that on 9 March organised and produced an opera burlesque, English Opera as She is Wrote, in which English, Italian, German, French and Russian opera styles were parodied in successive scenes. The performance was a great success and was repeated at several venues. It may have inspired Holst to use parody in his own opera, The Perfect Fool, which he began composing in 1918. In her spare time Joseph founded and ran a choir for Kensington nannies, which took part in local singing contests as the \"Linden Singers\".",
+          "context_id": "bcfb67f80182a4acaf06d9337288ae2c30fc75d6",
+          "qas": [
+            {
+              "question": "What is the name of the person who began teaching at Eothen in the autumn of 1916?",
+              "id": "9ff2bfda93ac7a624af00d4bb9d0ed81d71e073a",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 120
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who played the double-bass, but later took French horn lessons?",
+              "id": "ab9a4049f2c71c4903ed9d4ca03d6b13409c2e01",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 570
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who taught herself the timpani part for a summer concert?",
+              "id": "5be148f9e8f35994da58b7871e767d2ccc70f162",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 570
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the performance that may have inspired Holst to use parody in his own opera?",
+              "id": "2656747dbdc131ddb4c8bd6d6403e7dd1cd186f9",
+              "answers": [
+                {
+                  "text": "English Opera as She is Wrote",
+                  "answer_start": 1065
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "Joseph increased her teaching commitments by often deputising for Holst, both at James Allen's and at SPGS. She also continued in her role of the composer's amanuensis, and was invited to attend the private premiere of The Planets, on 29 September 1918 at the Queen's Hall, where Adrian Boult conducted the Queen's Hall orchestra. She later wrote: \"From the moment of Mars ... to the last sound of Neptune, it was a big thing that will last all our lives, I think\". She was able to draw on her classical education at Girton when she helped to translate the  apocryphal work The Acts of John from the original Greek, to provide the text for Holst's Hymn of Jesus (1917); for the same work she prepared a vocal score and an arrangement for piano, strings and organ. She and Holst combined to produce a women's voices version (two sopranos and an alto) of William Byrd's Mass for Three Voices, and Joseph worked alone to produce an orchestral accompaniment for Samuel Wesley's Sing Aloud with Gladness. This latter work was prepared for the 1917 Whitsun musical festival, one of an annual series of such festivals that Holst masterminded, first at his home town of Thaxted, in later years at assorted venues including Dulwich, Chichester and Canterbury. Joseph became a key figure in these festivals, as organiser, performer and composer. At Thaxted in 1918 two of her compositions were performed: Hymn for female voices (now lost), and an orchestral piece, Barbara Noel's Morris, which Joseph wrote to mark her friendship with the daughter of Conrad Noel, Thaxted's vicar.The years 1917 and 1918 also brought personal sadness. On 22 October 1917 Joseph's father died from a heart attack. On 27 May the following year, just after the Whitsun festival, her brother William was killed in action on the western front; in September, Edwin was severely wounded in the final Allied offensive of the war. In his monograph on Joseph's life and music, the composer Alan Gibbs writes that \"there is no hint in Jane's letters of the effect these events had on her\". Gibbs quotes Duff Cooper, who wrote of those times: \"... if we wept\u2014as weep we did\u2014we wept in secret\".",
+          "context_id": "7f692e20d432f9577fae00f59ff0b749f819c800",
+          "qas": [
+            {
+              "question": "What is the name of the person who was invited to attend the private premiere of The Planets?",
+              "id": "f37de64a8f866771b0910d3e32791f0c87294503",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who wrote: \"From the moment of Mars ... to the last sound of Neptune, it was a big thing that will last all our lives, I think\"?",
+              "id": "2b9a0c69dd0bb84b0b9677ca68e2fcacef760c9a",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who was able to draw on her classical education at Girton when she helped to translate the  apocryphal work The Acts of John from the original Greek?",
+              "id": "a498c911d56182e06246a933df8fe0fee0b69123",
+              "answers": [
+                {
+                  "text": "Joseph",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Drowning Girl",
+      "url": "https://en.wikipedia.org/wiki/Drowning_Girl",
+      "paragraphs": [
+        {
+          "context": "Drowning Girl is derived from the splash page from \"Run for Love!\", illustrated by Tony Abruzzo and lettered by Ira Schnapp, in Secret Hearts #83 (November 1962), DC Comics. This is the same comic book issue that inspired Hopeless.In 1963, Lichtenstein was parodying various types of sources such as commercial illustrations, comic imagery and even modern masterpieces. The masterpieces represented what could have been dubbed the \"canon\" of art and was thought of as \"high art,\" while the \"low-art\" subject matter included comic strip images. His masterworks sources included the likes of C\u00e9zanne, Mondrian and Picasso. During this time in his career, Lichtenstein noted that \"the things that I have apparently parodied I actually admire.\" At the time, Lichtenstein was exploring the theme of \"industrialization of emotion\". In Lichtenstein's obituary, Los Angeles Times critic Christopher Knight said the work was \"a witty rejoinder to De Kooning's famously brushy paintings of women\". His comic romances often depicted stereotypical representations of thwarted passions. Although the Lichtenstein Foundation website claims that Lichtenstein did not begin using his opaque projector technique until the fall of 1963, Lichtenstein described his process for producing comics based art, including Drowning Girl:\nAs directly as possible ... From a cartoon, photograph or whatever, I draw a small picture\u2014the size that will fit into my opaque projector ... I don't draw a picture to reproduce it\u2014I do it in order to recompose it ... I project the drawing onto the canvas and pencil it in and then I play around with the drawing until it satisfies me.\nWhen Lichtenstein had his first solo show at the Leo Castelli Gallery in New York City in February 1962, it sold out before the opening. In addition to Drowning Girl, the exhibition included Look Mickey, Engagement Ring, Blam and The Refrigerator. The show ran from February 10 through March 3, 1962.  According to the Lichtenstein Foundation website, Drowning Girl was part of Lichtenstein's first exhibition at Ferus Gallery in Los Angeles from April 1 \u2013 April 27, 1963, featuring Masterpiece, Portrait of Madame C\u00e9zanne and other works from 1962 and 1963. It was also part of his second solo exhibition at the Leo Castelli Gallery from September 28 \u2013 October 24, 1963 that included Torpedo...Los!, Baseball Manager, In the Car, Conversation, and Whaam!. Marketing materials for the show included the lithograph Crak! The Museum of Modern Art acquired Drowning Girl in 1971, and their webpage for this work credits Philip Johnson and Mr. and Mrs. Bagley Wright for the acquisition.",
+          "context_id": "0eb5ae7649153ba4a8df99a8357c66a3efa6a890",
+          "qas": [
+            {
+              "question": "What is the last name of the person whose first and second exhibitions included Drowning Girl?",
+              "id": "36d5c10b09137c554f1b7e1f839dbf7baca99700",
+              "answers": [
+                {
+                  "text": "Lichtenstein",
+                  "answer_start": 1967
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "In the early 1960s Lichtenstein's theme of comics-based work was hotly debated. In a 1963 New York Times article, Brian O'Doherty wrote that Lichtenstein's work was not art, saying Lichtenstein was \"one of the worst artists in America\" who \"briskly went about making a sow's ear out of a sow's ear.\" This was part of a widespread debate about the merits of Lichtenstein's comic blow-ups as true art. In January 1964 Life ran a story under the title \"Is He the Worst Artist in the U.S.?\" on this controversy. Later reviews were much kinder. Todd Brewster noted that this may have been motivated by popular demand; he told Life in 1986 that \"Those cartoon blowups may have disturbed the critics, but collectors, tired of the solemnity of abstract expressionism, were ready for some comic relief. Why couldn't the funny pages be fine art?\" His work is now widely accepted, although some criticize him for borrowing from comics without attributing the original creators, paying royalties, or seeking permission from copyright holders. David Barsalou has dedicated decades to identifying all of Lichtenstein's source materials and has posted more than 1,000 images on Flickr detailing Lichtenstein's unrecognized sources.Some critics question Lichtenstein's artistic skills. Everett Kinstler said that despite Lichtenstein's association with romance comics, in his day \"no comics publisher would have hired Lichtenstein\u2014he wasn't good enough.\" Kinstler said Lichtenstein lacked the ability to portray the emotional range of the story through facial expressions and body language independently.",
+          "context_id": "e83a0a9e11df95d2acdd510a3fe10176fb2db1a4",
+          "qas": [
+            {
+              "question": "What is the last name of the person who told Life that Lichtenstein's \"cartoon blowups may have disturbed the critics, but collectors, tired of the solemnity of abstract expressionism, were ready for some comic relief\"? ",
+              "id": "5d6f1b2e9456eac2720cc8b5815d911d1dc19210",
+              "answers": [
+                {
+                  "text": "Brewster",
+                  "answer_start": 545
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Hu Zhengyan 1",
+      "url": "https://en.wikipedia.org/wiki/Hu_Zhengyan",
+      "paragraphs": [
+        {
+          "context": "Hu Zhengyan was a noted seal-carver, producing personal seals for numerous dignitaries. His style was rooted in the classical seal script of the Han dynasty, and he followed the Huizhou school of carving founded by his contemporary He Zhen. Hu's calligraphy, although balanced and with a clear compositional structure, is somewhat more angular and rigid than the classical models he followed. Huizhou seals attempt to impart an ancient, weathered impression, although unlike other Huizhou artists Hu did not make a regular practice of artificially aging his seals.Hu's work was known outside his local area.  Zhou Lianggong, a poet who lived in Nanjing around the same time as Hu and was a noted art connoisseur, stated in his Biography of Seal-Carvers (Yinren Zhuan, \u5370\u4eba\u50b3) that Hu \"creates miniature stone carvings with ancient seal inscriptions for travellers to fight over and treasure\", implying that his carvings were popular with visitors and travellers passing through Nanjing.In 1644, Hu took it upon himself to create a new Imperial seal for the Hongguang Emperor, which he carved after a period of fasting and prayer. He presented his creation with an essay, the Great Exhortation of the Seal (Dabao Zhen, \u5927\u5bf6\u7bb4), in which he bemoaned the loss of the Chongzhen Emperor's seal and begged Heaven's favour in restoring it. Hu was concerned that his essay would be overlooked because he had not written it in the form of rhyming, equally-footed couplets (pianti, \u99e2\u9ad4) used in the Imperial examinations, but his submission and the seal itself were nevertheless both accepted by the Southern Ming court.",
+          "context_id": "8ee6ed691a09539c91f2dea8c47955c7feade63f",
+          "qas": [
+            {
+              "question": "What is the full name of the person whose carvings it is implied were popular with visitors and travellers passing through Nanjing?",
+              "id": "67048eb4a9e77eb77a30cef714e9353bc62c3e6b",
+              "answers": [
+                {
+                  "text": "Hu Zhengyan",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Orgazmo",
+      "url": "https://en.wikipedia.org/wiki/Orgazmo",
+      "paragraphs": [
+        {
+          "context": "Everyman Mormon missionary Joseph Young, assigned with his mission partner to Los Angeles, finds the city to be a hostile and unenthusiastic place for their work. The problems worsen when they knock on the door of sleazy porn director Maxxx Orbison and several security guards are sent to dispose of them. Joe defeats all of them singlehandedly with a variety of martial arts skills. Impressed by his performance and bored of his current project's lead actor, Orbison attempts to hire Joe to be the title character and lead of his pornographic superhero film, Orgazmo. Joe is conflicted because of his beliefs, but the salary offered would pay for a wedding in the temple in Utah where his fianc\u00e9e Lisa has expressed a strong desire to wed. Joe reluctantly accepts despite being given a sign from God.\nJoe finds the crew of the film intimidating but manages to befriend co-star Ben Chapleski, a technical genius and graduate from MIT who works in the pornographic industry to satiate his overactive libido. He plays Orgazmo's sidekick Choda Boy, who assists Orgazmo with specially designed sex toys, including Orgazmo's signature weapon, the Orgazmorator, a ray gun that forces orgasm upon whomever it is fired. Ben invites Joe to his home later on and shows Joe a real, working Orgazmorator Ben has built, and he and Joe spend an evening using it on unsuspecting citizens for amusement.\nAt a sushi bar owned by Ben's Japanese friend G-Fresh, the two witness a group of thugs vandalizing the bar in an attempt to force out G-Fresh so their dance club next door can expand. Later on, when Ben and Joe are not present, G-Fresh is coerced to leave. Upon finding this out, Joe and Ben don costumes and use their film props and the Orgazmorator to sneak into the club and steal back the contract G-Fresh was forced to sign. Joe is agitated after nearly being shot in the head but Ben is excited by finally getting to be a real superhero.",
+          "context_id": "9f98d1766e3439aeae90204a951c398643e2fcd7",
+          "qas": [
+            {
+              "question": "Who signed the contract that Joe and Ben want to steal back?",
+              "id": "0c7226460021feba33f551370e798dd0ac26098b",
+              "answers": [
+                {
+                  "text": "G-Fresh",
+                  "answer_start": 1523
+                }
+              ]
+            },
+            {
+              "question": "What is the superhero alias of the Mormon missionary?",
+              "id": "371b6836b363b20245af72f2f938640eff0e0ccd",
+              "answers": [
+                {
+                  "text": "Orgazmo",
+                  "answer_start": 560
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person who created the real working Orgazmorator?",
+              "id": "107bf2edc17ed17e2809c85e2631147dbbd121cb",
+              "answers": [
+                {
+                  "text": "Ben Chapleski",
+                  "answer_start": 878
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Lord of the Rings: The Two Towers",
+      "url": "https://en.wikipedia.org/wiki/The_Lord_of_the_Rings:_The_Two_Towers",
+      "paragraphs": [
+        {
+          "context": "Awakening from a dream of Gandalf the Grey battling the Balrog, Frodo Baggins and his friend Samwise Gamgee find themselves lost in the Emyn Muil near Mordor and soon become aware that they are being stalked by Gollum, the former owner of the One Ring. After capturing him, a sympathetic Frodo decides to use Gollum as a guide to Mordor, despite Sam's objections. \nMeanwhile, Aragorn, Legolas and Gimli pursue the Uruk-hai to save their companions Merry and Pippin. The Uruk-hai are ambushed by the Rohirrim, the exiled army of Rohan, while the two Hobbits escape into Fangorn Forest and encounter the Ent Treebeard. Aragorn's group later meets the Rohirrim and their leader \u00c9omer, who reveals that their king Th\u00e9oden is being manipulated by Saruman's servant Gr\u00edma Wormtongue into turning a blind eye to Saruman's forces running rampant in Rohan. While tracking down the Hobbits in Fangorn, Aragorn's group encounters Gandalf, who, after succumbing to his injuries while killing the Balrog in Moria, has been resurrected as Gandalf the White to help save Middle-earth.",
+          "context_id": "ec7d825e1e3cc2334d1a0ea0a9eec17417afb9d3",
+          "qas": [
+            {
+              "question": "What is the full name of the person who wants use Gollum as a guide to Mordor?",
+              "id": "c370cd37998cd03ef10b3f5cdd3d3f17c7f69805",
+              "answers": [
+                {
+                  "text": "Frodo Baggins",
+                  "answer_start": 64
+                }
+              ]
+            },
+            {
+              "question": "What are the names of the people in the group that meets the Rohirrim and their leader?",
+              "id": "ea548c6995efa373119defe3366fa98a15d4bc02",
+              "answers": [
+                {
+                  "text": "Aragorn",
+                  "answer_start": 376
+                },
+                {
+                  "text": "Legolas",
+                  "answer_start": 385
+                },
+                {
+                  "text": "Gimli",
+                  "answer_start": 397
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Air Cadet (film)",
+      "url": "https://en.wikipedia.org/wiki/Air_Cadet_(film)",
+      "paragraphs": [
+        {
+          "context": "In 1951,  Walt Carver, Russ Coulter, Jerry Connell and former U.S. Army Sgt. Joe Czanoczek join a group of cadets beginning air force pilot training. Each of the cadets have their own reasons for being in the United States Air Force with Carver attempting to overcome his privileged background, Coulter wanting to emulate his brother who had died in World War II, Connell trading on his prior background as a civilian pilot, and Sgt. Czanoczek vying to make his wartime military experience count.\nBesides flying, the trainees have to contend with Upper Classmen who are intent on hazing the newcomers. After primary training at Randolph Field on AT-6 Texan aircraft, the group loses one of their group, with Connell \"washing out\" and opting to become a navigator. All the others successfully solo and await their next assignment.\nThe rest of the group of trainees including Czanoczekas, who wanted to fly B-25 Mitchell medium bombers, move on to advanced training on jet aircraft at Williams Air Force Base. There cadet Coulter meets and falls in love with Janet Page, the estranged wife of one of the instructors, Major Jack Page, the leader of a F-80 Shooting Star jet aerobatics team based at Williams AFB. His job is to identify and wash out unsuitable candidates and with the turmoil at home, Page hones in on Coulter.\nThe rivalry between the two puts Coulter's future as a fighter pilot in jeopardy. Janet realizes that Coulter has aggravated some of Page's former demons. He had been tormented by the guilt of sending men to their deaths in wartime. After being branded a coward by Page, Coulter's brother had committed suicide, a secret that had been gnawing at the trainee.",
+          "context_id": "1d7aed63718856a8295b39ff2661bd9efca94ac4",
+          "qas": [
+            {
+              "question": "What is the full name of the character who has a job which entails identifying unsuitable candidates?",
+              "id": "562d8e2a506bf8a82ff9a2db4a0b3a2e61ef2d7a",
+              "answers": [
+                {
+                  "text": "Jack Page",
+                  "answer_start": 1121
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the former cadet who left pilot training to become a navigator?",
+              "id": "efc85250409a60b7440f03e003a1a4d93b9ecb21",
+              "answers": [
+                {
+                  "text": "Jerry Connell",
+                  "answer_start": 37
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "American Gangster (film)",
+      "url": "https://en.wikipedia.org/wiki/American_Gangster_(film)",
+      "paragraphs": [
+        {
+          "context": "In 1968, Frank Lucas is the right-hand man of Harlem gangster Ellsworth \"Bumpy\" Johnson. When Johnson dies of a heart attack, Lucas takes control of the Harlem crime scene.\nAfter handing in almost $1 million that he found in a mobster's car, Newark detective Richie Roberts is ostracized in his precinct. After his exiled and addicted partner overdoses on a potent brand of  heroin called \"Blue Magic\", Captain Lou Toback puts Roberts in charge of a task force  that targets local suppliers. Lucas buys Blue Magic directly from producers in Thailand and smuggles it into the U.S. through returning Vietnam War servicemen. His low overhead allows him to eventually wholesale Blue Magic to most of the dealers in the New York area. With this monopoly, Lucas expands his control to nightclubs, casinos, and prostitution. He buys a mansion for his mother and recruits his five brothers, including Huey and Turner, as lieutenants to spread his empire. During his rise to becoming Harlem's crime boss, Lucas falls in love with Eva, a Puerto Rican beauty queen.",
+          "context_id": "3cfb30039abb2e6b9f8113f8a9e9facfe144ddf0",
+          "qas": [
+            {
+              "question": "What's the full name of the person responsible for the heroin that a cop overdoses on?",
+              "id": "700f63d26e69d437327ed7b2d26425e76f23212f",
+              "answers": [
+                {
+                  "text": "Frank Lucas",
+                  "answer_start": 9
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Time Gentlemen, Please!",
+      "url": "https://en.wikipedia.org/wiki/Time_Gentlemen,_Please!",
+      "paragraphs": [
+        {
+          "context": "The Prime Minister undertakes a tour of the cities and towns with the highest percentage figures of employment: Glasgow, Newcastle, Cardiff, and at the top of the list at 99.9%, Little Hayhoe, a small town in Essex (filmed in Thaxted) with a population of 2,000. The 0.1% is Irishman Daniel \"Dan\" Dance, who is well-liked by most of the residents. The village  council, however, are eager to put him out of the way before the Prime Minister arrives. Councillor Eric Hace orders the village's only policeman, Police Constable Tumball to arrest Dan for skipping out without paying his bill at Hace's pub. Sir Digby Montague, as the head of the council and the local magistrate, plans to sentence him to a week in the gaol.\nWhen Sir Digby finds that his maid Sally, who happens to be Dan's granddaughter, has been giving Dan Sir Digby's leftovers for dinner regularly, he promptly sacks her.\nMiss Mouncey, another council member, comes up with a notion: Dan should go live in the almshouse, which has been empty for 50 years. Vicar Reverend Simpson informs the Crouches, the custodians, that the regulations are to be strictly enforced, even though they are 400 years old. Among other things, the rules dictate that he be washed by the matron every night and wear an old-fashioned uniform. When he returns drunk the next night, he is put in stocks. Displeased by this, the villagers pelt Timothy Crouch with food.\nBill Jordan is sympathetic to Dan's plight (and attracted to Sally). He reminds the councillors that an election will be held before the Prime Minister's visit. ",
+          "context_id": "f8dd589f192ac0fd51dc6705c9d7642c9f4f11c6",
+          "qas": [
+            {
+              "question": "Who is put in stocks?",
+              "id": "3d00c8427fc32a45327f1b4f432f36408d290cb4",
+              "answers": [
+                {
+                  "text": "Daniel \"Dan\" Dance",
+                  "answer_start": 284
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person who has a made named Sally?",
+              "id": "6017debc7c7d77c66d24397ecb3b0ca87e31c9bf",
+              "answers": [
+                {
+                  "text": "Digby Montague",
+                  "answer_start": 607
+                }
+              ]
+            },
+            {
+              "question": "What is the nickname of Sally's grandfather?",
+              "id": "11583222899e490150061078aca65c71b34709e0",
+              "answers": [
+                {
+                  "text": "Dan",
+                  "answer_start": 292
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "\"Say Say Say\" 0",
+      "url": "https://en.wikipedia.org/wiki/Say_Say_Say",
+      "paragraphs": [
+        {
+          "context": "McCartney biographer Ray Coleman asserted that the majority of the song's lyrics were written by Jackson and given to McCartney the next day. Recording began at AIR Studios in London in May 1981. At the time, McCartney was recording Tug of War, the former Beatle's first solo album after the breakup of his group Wings.Jackson stayed at the home of McCartney and his wife Linda during the recording sessions, and became friends with both. While at the dining table one evening, Paul McCartney brought out a booklet that displayed all the songs to which he owned the publishing rights. \"This is the way to make big money\", the musician informed Jackson. \"Every time someone records one of these songs, I get paid. Every time someone plays these songs on the radio, or in live performances, I get paid.\" McCartney's words influenced Jackson's later purchase of ATV Music Publishing in 1985.\nMcCartney played several instruments on \"Say Say Say\", including percussion, synthesiser, guitar, and bass guitar. The harmonica was played by Chris Smith and the rhythm guitar was played by David Williams. The song was engineered by former Beatles sound engineer, Geoff Emerick. The production of \"Say Say Say\" was completed in February 1983, after it had been refined and overdubbed at Cherokee Studios in California.\nGeorge Martin, who had worked with The Beatles, produced the song. He said of his experience with Jackson, \"He actually does radiate an aura when he comes into the studio, there's no question about it. He's not a musician in the sense that Paul is ... but he does know what he wants in music and he has very firm ideas.\"Jackson also spoke of the experience in his autobiography, Moonwalk. The younger singer revealed that the collaboration boosted his confidence, as Quincy Jones\u2014producer of Thriller\u2014was not present to correct his mistakes. Jackson added that he and McCartney worked as equals, stating, \"Paul never had to carry me in that studio.\"According to Musicnotes.com by Alfred Music Publishing, \"Say Say Say\" was performed in common time, with a dance beat of 116 beats per minute. It is in the key of B\u266d minor and sung in a vocal range from F3 to B\u266d4. The lyrics to \"Say Say Say\" reflect an attempt to \"win back\" a girl's affection; Deseret News considered the song to be a \"pleading kind of love song\".",
+          "context_id": "e4481f4fdc365dfd5d1bd1e81780c85ab4a8f702",
+          "qas": [
+            {
+              "question": "What is the last name of the person Michael said never had to carry him in the studio?",
+              "id": "6d5ec494905e389c193450d1ede9c9c942bfc06d",
+              "answers": [
+                {
+                  "text": "McCartney",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Hours of Mary of Burgundy",
+      "url": "https://en.wikipedia.org/wiki/Hours_of_Mary_of_Burgundy",
+      "paragraphs": [
+        {
+          "context": "The Hours of Mary of Burgundy (German: Stundenbuch der Maria von Burgund) is a book of hours, a form of devotional book for lay-people, completed in Flanders around 1477. It was probably commissioned for Mary of Burgundy, then the wealthiest woman in Europe; Mary was the only child of Charles the Bold, Duke of Burgundy and wife of Maximilian I, ruler of the Holy Roman Empire. No records survive as to its commission. The book contains 187 folios, each measuring 22.5 by 15 centimetres (8.9 in \u00d7 5.9 in). It consists of the Roman Liturgy of the Hours, 24 calendar roundels, 20 full-page miniatures and 16 quarter-page format illustrations. Its production began c.\u20091470, and includes miniatures by several artists, of which the foremost was the unidentified but influential illuminator known as the Master of Mary of Burgundy, who provides the book with its most meticulously detailed illustrations and borders. Other miniatures, considered of an older tradition, were contributed by Simon Marmion, Willem Vrelant and Lieven van Lathem. The majority of the calligraphy is attributed to Nicolas Spierinc, with whom the Master collaborated on other works and who may also have provided a number of illustrations. \nThe two most well known illustrations contain a revolutionary trompe-l'oeil technique of showing a second perspective through an open window from the main pictorial setting. It is sometimes known as one of the black books of hours, due to the dark and sombre appearance of the first 34 pages, in which the gilded letter was written on black panels. The book has been described as \"undoubtedly [...] among the most important works of art made in the late middle ages...a milestone in the history of art and one of the most precious objects of the late middle ages\". Given the dark colourisation and mournful tone of the opening folios, the book may originally have been intended to mark the death of Charles, who died aged 43 in 1477 at the Battle of Nancy. Mid-ways through its production it is thought to have been recommissioned as gift to celebrate Mary's marriage to Maximilian. Tonally the early pages change from dark, sombre colours to a later sense of optimism and unity.",
+          "context_id": "6f2ec61198379940dd418a32afa81aaa95e95696",
+          "qas": [
+            {
+              "question": "What is the German name of the book that was likely commissioned for the then wealthiest woman in Europe, Mary of Burgundy?",
+              "id": "84d10349328e0f63402845d4dcc9c70d174eb30c",
+              "answers": [
+                {
+                  "text": "Stundenbuch der Maria von Burgund",
+                  "answer_start": 39
+                }
+              ]
+            },
+            {
+              "question": "What is the German name of the book that consists of the Roman Liturgy of the Hours, 24 calendar roundels, 20 full-page miniatures and 16 quarter-page format illustrations?",
+              "id": "eee50e95459a3e1fd281ac59bfc17a65ee43cb27",
+              "answers": [
+                {
+                  "text": "Stundenbuch der Maria von Burgund",
+                  "answer_start": 39
+                }
+              ]
+            },
+            {
+              "question": "What is the German name of the book whose most meticulously detailed illustrations and borders were provided by an unidentified but influential illuminator known as the Master of Mary of Burgundy?",
+              "id": "58458621520296c6e62425219f70ac2343bb3078",
+              "answers": [
+                {
+                  "text": "Stundenbuch der Maria von Burgund",
+                  "answer_start": 39
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Cradle 2 the Grave",
+      "url": "https://en.wikipedia.org/wiki/Cradle_2_the_Grave",
+      "paragraphs": [
+        {
+          "context": "Anthony Fait attempts to steal diamonds for a Frenchman named Christophe, who serves as the middleman for a mysterious employer. When Fait contacts Christophe, a Taiwanese Intelligence Agent named Su intercepts the conversation and attempts to identify the criminals.\nWhile the crew gathers up as many diamonds as they can, including a bag of black diamonds, Agent Su calls Fait and demands that he and his crew leave the diamonds in the vault, warning him that the police are on the way. However, Fait ignores this warning, and the criminals attempt a daring escape past a SWAT team blockade. While Fait, Daria, and Tommy all manage to escape, Agent Su captures Miles and recovers Miles' share of the diamonds. Su is disappointed to find that Miles does not have the black diamonds though. Meanwhile, Fait asks his friend Archie to appraise the black diamonds he had stolen. Arriving at the San Francisco International Airport, Christophe's mysterious employer, Ling, is informed, by his assistant Sona, that Christophe has been attacked and that Fait and his gang have taken the black diamonds.\nLater that night, Fait runs into Su. During this inadvertent meeting, Fait receives a phone call from Ling, who demands that Fait hand over the black diamonds. Fait refuses and is subsequently attacked by two of Ling's henchman. With Su's help, he defeats them and escapes. After the fight, Archie tells Fait that some gangsters came to his workshop and demanded the black diamonds as well. After some hesitation, Archie admits that he gave the stones to the gangsters to spare his own life. Fait also receives another call from Ling, who has kidnapped Fait's daughter, Vanessa, to persuade Fait to give up the diamonds. Now with a common enemy, Fait and Su team up to recover the diamonds from the gangsters and rescue Vanessa from Ling.",
+          "context_id": "9e5ac1207babe157eb6fece4e62b2594ca3d06f7",
+          "qas": [
+            {
+              "question": "What is the last name of the person who is told to leave the diamonds in the vault?",
+              "id": "80cb6ddbab8ad3b00ac3f0391a766428008d3f99",
+              "answers": [
+                {
+                  "text": "Fait",
+                  "answer_start": 374
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who defeats two henchmen?",
+              "id": "cced328334cfdce1209760616fb91e83318879e9",
+              "answers": [
+                {
+                  "text": "Fait",
+                  "answer_start": 1257
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Affliction (1997 film)",
+      "url": "https://en.wikipedia.org/wiki/Affliction_(1997_film)",
+      "paragraphs": [
+        {
+          "context": "The film begins with a voice-over narration by Rolfe Whitehouse, announcing the story of his brother Wade's \"strange criminal behavior\" and subsequent disappearance.\nWade Whitehouse is a small-town policeman in New Hampshire. On Halloween night, Wade meets his daughter Jill from his divorced marriage, but he is late and the evening is overshadowed by disharmony. Jill eventually calls her mother to come and pick her up. When his ex-wife finally arrives, Wade shoves her lover against their car and watches them drive away with Jill. Wade vows to get a lawyer to help gain custody of his daughter.\nThe next day, Wade rushes to the scene of a crime. Jack Hewitt, hunting guide claims that Evan Twombley, with whom he was hunting, accidentally shot and killed himself. The police believe Jack, but Wade grows suspicious, believing that the man's death was no accident. When he is informed that the victim was scheduled to testify in a lawsuit, his suspicion slowly turns into conviction.\nA while later, Wade and his girlfriend Margie Fogg arrive at the house of Wade's father, Glen Whitehouse, whose abusive treatment of Wade and Rolfe as children is seen in flashbacks throughout the film. Wade finds his mother lying dead in her bed from hypothermia. Glen Whitehouse reacts to her death with little surprise. At the funeral wake, the father gets drunk and loudly exclaims, \"Not one of you is worth one hair on that woman's head!\", resulting in a confrontation between himself and Wade.",
+          "context_id": "0c021db8e13c52b37ae485e560391d8ab398cc98",
+          "qas": [
+            {
+              "question": "What is the full name of the person that is told about Evan's role as a trial witness?",
+              "id": "70828cecf4702d279295a633ac2075104a4dbc92",
+              "answers": [
+                {
+                  "text": "Wade Whitehouse",
+                  "answer_start": 166
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person that becomes convinced that Evan's death was no accident?",
+              "id": "b7deced83eef35b95ff42cd7a2bb0796ca9314fc",
+              "answers": [
+                {
+                  "text": "Wade",
+                  "answer_start": 798
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person that gets drunk at the wake?",
+              "id": "ab1365e58abf8a323712ed9338e4b5a1b457a1dd",
+              "answers": [
+                {
+                  "text": "Glen Whitehouse",
+                  "answer_start": 1077
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Silent Cry (film)",
+      "url": "https://en.wikipedia.org/wiki/Silent_Cry_(film)",
+      "paragraphs": [
+        {
+          "context": "Rachel Stewart is devastated to learn her newborn has died shortly after birth, but a short while later, she begins to suspect the baby has been abducted. Certain that there's only one way to find out the truth, Rachel returns to the hospital. Here she encounters the menacing Dennis Betts, and in an attempt to flee from him, she \u00eds forced to hide in a car belonging to Daniel Stone, a hospital porter. Initially reluctant to help, Daniel's conscience eventually gets the better of him. Rachel's world is further rocked by the death of her best friend Annie, and the discovery that Dennis Betts is actually a policeman, with his own very personal reasons for pursuing Rachel. As Rachel and Daniel race through London's nightscape, desperate to stay one step ahead of Betts, every discovery unleashes further hell, extending way beyond the disappearance of Rachel's baby. Their only solid lead seems to be Joanne, a young prostitute, whose own baby provides a link. But with Betts systematically eliminating anyone in his way, a further web of conspiracy unfolds and Rachel and Daniel are led to her old family doctor, Robert Barrum.",
+          "context_id": "da408955c1d9f25003bad3424ee01097a2470d83",
+          "qas": [
+            {
+              "question": "What is the first name of the person who attempts to flee from someone menacing?",
+              "id": "685f79bf9e97545c85c2ee6998fdd7611909889a",
+              "answers": [
+                {
+                  "text": "Rachel",
+                  "answer_start": 212
+                }
+              ]
+            },
+            {
+              "question": "What are the first names of the people who have only one solid lead?",
+              "id": "eea3b98e2a45ee42a588157e073232d29b97fc5b",
+              "answers": [
+                {
+                  "text": "Rachel",
+                  "answer_start": 680
+                },
+                {
+                  "text": "Daniel",
+                  "answer_start": 691
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Miss Firecracker",
+      "url": "https://en.wikipedia.org/wiki/Miss_Firecracker",
+      "paragraphs": [
+        {
+          "context": "Carnelle enters the Miss Firecracker beauty pageant which her hometown of Yazoo City, Mississippi, stages every Fourth of July, hoping to emulate her cousin Elain's (Mary Steenburgen) win some years previous. Carnelle was taken in as a waif by her genteel cousins after the death of her mother and grows up promiscuous, brash, unfeminine and lacking in grace. Few expect she can win, her closest friends and relatives think she is heading for a big disappointment, but Carnelle is ever hopeful. \nWhen her other cousin, the eccentric sociopath Delmount, decides to sell the house they both live in to make money, Carnelle becomes even more determined to win, viewing it as a way to escape her small town existence. Elain returns to the town to give a speech at the pageant after a breakup with her husband. Carnelle insists Elain let her wear the red dress in which she won the contest, thinking that will guarantee her success. Elain delays giving Carnelle the dress and makes excuses as to why she cannot have it while pretending to be supportive. \nCarnelle surprisingly gets on the shortlist for the pageant when one of the other contestants pulls out. Without a red dress she breaks into a locked room in the house previously occupied by a sick relative and takes an old dress to wear. She comes last at the final and is frustrated by her failure. Back at the house, she discovers Elain had brought the dress with her all along and had been lying to her. She confronts Elain about this, realizing the pageant is not the most important thing after all, then leaves the house and goes to the town observatory and watches the pageant fireworks display.",
+          "context_id": "b9de4b08e2f63e5ba651a342c14e00133316ae0b",
+          "qas": [
+            {
+              "question": "What is the name of the person that had a cousin win Miss Firecracker?",
+              "id": "8997f5e550a0915e36e5c29093e728f6c7616ab2",
+              "answers": [
+                {
+                  "text": "Carnelle",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person that grew up promiscuous?",
+              "id": "ba2671c49a9ff1d4071c92f0e4e56b261984a844",
+              "answers": [
+                {
+                  "text": "Carnelle",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person that Delmount lives with?",
+              "id": "43c53fdff911b4a841070fd7a01e3f48588c6570",
+              "answers": [
+                {
+                  "text": "Carnelle",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person that watched the fireworks display from the observatory?",
+              "id": "6692feafbfebc394649904fe69a3e9e36c0162ae",
+              "answers": [
+                {
+                  "text": "Carnelle",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person whose cousin won the beauty pageant several years ago? ",
+              "id": "2ac8d170a6b73c1b44289d47a80f3f1cd93d727c",
+              "answers": [
+                {
+                  "text": "Carnelle",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Silent Night, Deadly Night Part 2",
+      "url": "https://en.wikipedia.org/wiki/Silent_Night,_Deadly_Night_Part_2",
+      "paragraphs": [
+        {
+          "context": "The sequel picks up on Christmas Eve some years after the first movie, with Ricky Caldwell, the 18-year-old brother of the first film's killer, now being held in a mental hospital, awaiting trial for a series of murders that he committed. While being interviewed by the psychiatrist Dr. Henry Bloom, Ricky tells the story of the murders his brother Billy committed throughout a series of several flashbacks using footage from the original film. These flashbacks have new shots to make Ricky appear in more of Billy's original story.\nAfter this, Ricky tells his own story: after Billy's death, he was adopted and given a good upbringing, but his trauma was never treated. After his foster father's death, Ricky loses his composure and commits a series of random murders, targeting people who are \"naughty\". A chance for a normal life seems to appear when he starts dating Jennifer Statson, but an unpleasant encounter with Jennifer's ex-boyfriend Chip sends Ricky over the edge. He kills Chip by electrocuting him with jumper cables that are attached to a car while Jennifer watches, and uses the car antenna to strangle Jennifer to death. A security guard witnesses this and as Ricky is about to get arrested, he grabs the guard's gun, shoots him in the forehead, and goes on a shooting spree. He kills at least three more people throughout a suburban neighborhood, including shooting one man through a garbage can after yelling \"Garbage Day!\" Later on, Ricky gets himself into a stand-off where he tries and fails to commit suicide before getting arrested by the police.",
+          "context_id": "62ae811e33a997f7bcb3b7f07570c33457e4be18",
+          "qas": [
+            {
+              "question": "Who does the man that electrocutes someone to death kill by strangulation?",
+              "id": "9b93fe7d27e25f25ae9c84cf47d1274fded06a83",
+              "answers": [
+                {
+                  "text": "Jennifer",
+                  "answer_start": 1120
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Splash (film)",
+      "url": "https://en.wikipedia.org/wiki/Splash_(film)",
+      "paragraphs": [
+        {
+          "context": "In 1964, eight-year-old Allen Bauer is vacationing with his family near Cape Cod. While taking a sight-seeing tour on a small boat, he sees something below the ocean surface that fascinates him, and jumps into the water even though he cannot swim. Underwater, he encounters a mermaid girl and inexplicably finds himself able to breathe under water. However, Allen is pulled back to the surface, and the two are separated. Since no one else has seen the girl, Allen comes to believe the encounter was a near-death hallucination, but his subsequent relationships with women fail as he subconsciously seeks the connection he felt with the mysterious girl.\nTwenty years later, Allen is now co-owner of a wholesale fruit and vegetable business in New York City with his womanizing brother Freddie. Depressed after his latest breakup, Allen returns to Cape Cod, where he encounters eccentric scientist Dr. Walter Kornbluth, who is determined to discover legendary sea creatures. When a motorboat fails, Allen falls into the sea and is knocked out when the boat hits his head. He wakes up with a headache on a beach, where he encounters a beautiful naked woman with long blonde hair and the inability to talk (Daryl Hannah). After kissing him, she dives into the sea, where she transforms into a mermaid. While swimming underwater, she is sighted by Kornbluth.",
+          "context_id": "c0106ccf2d0180d94b4f0093eb679b5355f6e1a3",
+          "qas": [
+            {
+              "question": "What is the full name of the person who jumps into the water despite an inability to swim?",
+              "id": "68685d990bdd0812e3566ca95ab4e153454543ab",
+              "answers": [
+                {
+                  "text": "Allen Bauer",
+                  "answer_start": 24
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person that is depressed after a breakup?",
+              "id": "f64a9894ee71fc2c7642b96a025aeccb02709de9",
+              "answers": [
+                {
+                  "text": "Allen",
+                  "answer_start": 673
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Journey to Promethea",
+      "url": "https://en.wikipedia.org/wiki/Journey_to_Promethea",
+      "paragraphs": [
+        {
+          "context": "The movie opens with a narration describing the fate of the Samillian Tribe; once a noble people, they were subjugated by the despotic King Laypach and condemned to wander aimlessly in the wilderness. The Samillians rebelled against King Laypach, under the command of their mightiest warrior and holy leader, Draden, who slew over a thousand of Laypach's men. After a 23-year struggle, Draden is captured and beheaded.  Before his execution, however, he prophesies that his spirit will descend upon a member of the Samillians, who will then lead them against their oppressors and to the holy land of Promethea.\nEight years later, Grado Amurilus, son of the deposed King of the Samillians, is living as a farmer with his own boys, Magnus and Binon. Despite a century-and-a-half of Samillian oppression, they live an idyllic life, seemingly untouched by Laypach's tyranny. Meanwhile, King Laypach is informed by his Wise Men that Draden's prophecy has come to pass, and that the chosen liberator of the Samillian tribe has come of age.  They warn that King Laypach must not allow the boy to unite with Draden's daughter, Aria, and receive Draden's sword.  If the chosen one uses the sword to pierce the ancient Stone of Groboda\u2014which was blessed by the gods after it fell to the earth\u2014King Laypach will turn to dust.  They tell him the chosen boy will possess \"the light\" of Draden in his eyes.  King Laypach dismisses the wise men and orders the boy found and brought before him.",
+          "context_id": "087eb1f6de6922c3ba79e2bde382f9f7af7bf8e1",
+          "qas": [
+            {
+              "question": "Who says that the chosen boy will possess \"the light\" of Draden in his eyes?",
+              "id": "7d9d712ea4c4df8ed10783b2588f11ca34804a63",
+              "answers": [
+                {
+                  "text": "Wise Men",
+                  "answer_start": 914
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Bait (1921 film)",
+      "url": "https://en.wikipedia.org/wiki/The_Bait_(1921_film)",
+      "paragraphs": [
+        {
+          "context": "Joan Grainger is about to be \"sent up\" to prison after being falsely accused of stealing when she is kidnapped by Bennett Barton, mastermind of a band of crooks of which Simpson is a member. Joan accepts Bennett's assistance when he sends her to Europe and later joins her. They live in luxury when she meets John Warren, a wealthy American. Joan receives her first jar of suspicion when Bennett introduces her to John as being Bennett's daughter. Bennett later tells her the plan is for her to marry John so that they will have access to the money. The girl rebels but Bennett threatens to send her back to prison or, still worse, expose her to John, with whom she has now fallen in love. The entire party return to the United States where Bennett forces Joan to accept John's proposal of marriage. In the meantime some members of Bennett's gang have double-crossed him and tell Joan of the original theft frame-up. A signed confession is secured from the girl that did the framing. In the effort to secure the confession, Bennett is killed by Simpson, who had been after the \"goods\" on Bennett. John is willing to have Joan despite all of this and they are happy.",
+          "context_id": "6380d30175c9ab81e21c28882cdaf77c19d65d3b",
+          "qas": [
+            {
+              "question": "What is the last name of the person that Joan accepts help from? ",
+              "id": "d7d19bfcb82e01ba075d142a86152a7929b49a5e",
+              "answers": [
+                {
+                  "text": "Barton",
+                  "answer_start": 122
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person that Joan falls in love with? ",
+              "id": "ee79aa0d41487cc07905f416cd0d9407a2e2a212",
+              "answers": [
+                {
+                  "text": "John Warren",
+                  "answer_start": 309
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who forces Joan to accept John's proposal? ",
+              "id": "6a2f026c4bfcc57adebb83061eb9417fe84e9e1b",
+              "answers": [
+                {
+                  "text": "Barton",
+                  "answer_start": 122
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "When Trumpets Fade",
+      "url": "https://en.wikipedia.org/wiki/When_Trumpets_Fade",
+      "paragraphs": [
+        {
+          "context": "Private David Manning is a soldier in the 28th Infantry Division who, in order to survive, does just enough to stay out of trouble but not enough to actually make a difference. Through the sheer bloodiness of the H\u00fcrtgen battles, Manning is left as the sole survivor of his platoon. He is assigned to lead a squad of green reinforcements and promoted to sergeant. He tries to get out of it, saying he is unqualified for the position, but his company commander, Captain Roy Pritchett, thinks otherwise. Manning then tries to back out of responsibility by asking to be filed on a Section 8 (designating him mentally unfit due to combat stress), but is refused.\nLeading a squad of replacements on the front line is a prospect he is less than thrilled with. He meets with his new men, and during the evening, leads them into position on the line. \nThe next morning, on patrol with his squad, Manning puts Private Warren Sanderson on point. Sanderson goes forward too quickly, gets separated from the squad, and then narrowly avoids contact with the enemy. \nAfter some time, Manning decides the squad must leave without Sanderson. At that moment, Sanderson returns. After the incident, Manning is scorned by his peers and berated by his platoon leader, First Lieutenant Terrence Lukas.\nManning's company makes a push toward the town of Schmidt, to take and hold a bridge. However, they move into an enemy minefield and are shelled by 88mm guns. \nThey retreat, and Pritchett comes to Manning with a mission that he requires volunteers for. Manning wishes him luck, so Pritchett offers Manning a Section 8 if he volunteers for and succeeds on the mission. ",
+          "context_id": "52dbb00212a35758d30af7ff35691a841e76d8a5",
+          "qas": [
+            {
+              "question": "What rank does the survivor of the H\u00fcrtgen battles attain?",
+              "id": "4c3dc27c75de9f12dba0d24ef945c4d1502d6f2e",
+              "answers": [
+                {
+                  "text": "sergeant",
+                  "answer_start": 354
+                }
+              ]
+            },
+            {
+              "question": "What does the company commander task the sergeant with?",
+              "id": "5fbe5900c177c1fcdbe0984dfd35593ef18824c9",
+              "answers": [
+                {
+                  "text": "lead a squad of green reinforcements",
+                  "answer_start": 301
+                }
+              ]
+            },
+            {
+              "question": "What's the rank of the man who needs volunteers for a mission?",
+              "id": "ad834dc736b2c307af0955f820e8f4a0204b5edd",
+              "answers": [
+                {
+                  "text": "Captain",
+                  "answer_start": 461
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Outcasts of Poker Flat (1952 film)",
+      "url": "https://en.wikipedia.org/wiki/The_Outcasts_of_Poker_Flat_(1952_film)",
+      "paragraphs": [
+        {
+          "context": "Ryker, a murderous western outlaw, leaves death and destruction behind after a robbery in Poker Flat and leaves the loot with his wife, Cal, before riding off. A while later, the shaken town decides to banish all undesirables. They include gambler John Oakhurst, saloonkeeper and madam The Duchess and the town drunk, as well as Cal, who had been spotted with Ryker, even though no one knows they are husband and wife.\nThe others follow Oakhurst, not knowing what else to do. They come across young Tom Dakin and pregnant sweetheart Piney, who were headed for Poker Flat to be wed. In a snowstorm, John leads them to a remote cabin. They have no horses, so Tom takes off for Poker Flat on foot to get help, given $500 of the stolen money by Cal in case he needs to pay someone to form a rescue party.\nRyker turns up, also on foot. He is shocked to find Cal, becomes suspicious and beats her, as well as bullying the others and eating all of their remaining food. He shoots the drunk just for taking a bottle of whiskey. Cal develops a bond with Oakhurst and eventually reveals her situation to him. A fight begins after Ryker shoots and kills The Duchess in cold blood, and Oakhurst is able to strangle him to death. Some head back toward town, while Oakhurst and Cal go the other way.",
+          "context_id": "5a79b11b9f96aa22e436ecc15ab1643017113cdd",
+          "qas": [
+            {
+              "question": "Who does Oakhurst strangle to death?",
+              "id": "6dea9ee139685370a161b73a529b14079b62b25b",
+              "answers": [
+                {
+                  "text": "Ryker",
+                  "answer_start": 1120
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Bridge to the Sun",
+      "url": "https://en.wikipedia.org/wiki/Bridge_to_the_Sun",
+      "paragraphs": [
+        {
+          "context": "Gwen Harold, an American woman from Tennessee, meets Hidenari Terasaki (called Terry by his friends and family), the secretary to the Japanese Ambassador, while attending a reception at the Japanese Embassy in Washington D.C. with her Aunt Peggy and friend Bill.  They share a moment while Terry is showing her the antique Japanese artworks on display in the Embassy, and after some reluctance, she agrees to allow him to call on her.\nThey begin dating and they quickly fall in love, even though Terry occasionally has fits of anti-western sentiment.  When Terry asks her to marry him, she agrees, much to the chagrin of Aunt Peggy (who was raised in the Jim Crow South), and who sees the relationship as unnatural, especially when there are \"nice clean young men\" available.  The Japanese Ambassador also calls on Gwen and attempts to dissuade her from accepting, claiming it would hurt Terry's career by giving him an American bias, and states that even though the two countries are friendly, anything could happen between foreign countries.  He seems to hint at possible aggression in the future, even though it is only 1935 and the Japanese have not yet resumed conflicts with China, keeping the countries of Gwen and Terry at an uneasy peace. They eventually marry despite the obstacles and, when Terry is recalled, travel to Japan by ship.\nAlmost immediately after disembarking and arriving in Tokyo, Terry begins to treat Gwen much differently, expecting her to behave according to the male-centric beliefs of contemporary Japan, such as being silent among men, always entering doors after the men, and virtually bending to every whim of Terry and her male relatives.  They continually fight and make up, mostly because of Gwen's outspokenness among men and Terry's strict adherence to the local customs.",
+          "context_id": "04039058b4c6499becccc0e12c026e3b3b10ee9f",
+          "qas": [
+            {
+              "question": "What are the full names of the bride and groom?",
+              "id": "b23c73ebd89161df0a3c45bb16a3ad1f8085a04a",
+              "answers": [
+                {
+                  "text": "Gwen Harold",
+                  "answer_start": 0
+                },
+                {
+                  "text": "Hidenari Terasaki",
+                  "answer_start": 53
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Olympus Has Fallen",
+      "url": "https://en.wikipedia.org/wiki/Olympus_Has_Fallen",
+      "paragraphs": [
+        {
+          "context": "Former Army Ranger Mike Banning is the lead U.S. Secret Service agent assigned to head the U.S. Presidential detail. Banning maintains a personal, friendly relationship with President Benjamin Asher, First Lady Margaret and their son Connor. During a snowy Christmas evening drive from Camp David to a campaign fundraiser, the car transporting the First Family spins out of control on a bridge due to icy conditions; Banning pulls Asher from the vehicle, but fails to save Margaret as she falls to her death inside the car.\nEighteen months later, having been removed from the presidential detail, Banning works at Treasury headquarters. During a meeting between Asher and South Korean Prime Minister Lee Tae-Woo at the White House, a North Korean terrorist organization, led by Kang Yeonsak, mounts an air and ground assault that results in the capture of the building. The group is aided by treasonous members of the prime minister's own detail, including Dave Forbes, a former Secret Service agent. Asher and several top officials are held hostage in the White House bunker; South Korean Prime Minister Lee is executed on live video. Before his own death, detail agent Roma alerts the Director of the Secret Service Lynne Jacobs that \"Olympus has fallen\".\nDuring the initial assault by Kang's forces, Banning joins the White House's defenders. He falls back into the White House, disabling the internal surveillance and gaining access to Asher's satellite ear phone, which he uses to maintain contact with Jacobs and Speaker of the House Allan Trumbull, now the Acting President.",
+          "context_id": "93877b71cd2192a6491f181d1332d0627332b0e8",
+          "qas": [
+            {
+              "question": "What is the first name of the person that falls back into the White House to disable surveillance?",
+              "id": "bc66a50d216029d9b50e5165ce2d34030ec680f5",
+              "answers": [
+                {
+                  "text": "Mike",
+                  "answer_start": 19
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Dune (1984 film)",
+      "url": "https://en.wikipedia.org/wiki/Dune_(1984_film)",
+      "paragraphs": [
+        {
+          "context": "In the distant future, the known universe is ruled by Padishah Emperor Shaddam IV. The most important substance in the empire is the drug known as melange or \"the spice\". It has many special properties, such as extending life and expanding consciousness. The most profitable and important of its properties is its ability to assist the Spacing Guild with folding space, which allows safe, instantaneous interstellar travel.\nSensing a potential threat to spice production, the Spacing Guild sends an emissary to demand an explanation from the Emperor, who confidentially shares his plans to destroy House Atreides. The popularity of Duke Leto Atreides has grown through the empire, and he is suspected to be amassing a secret army, which Emperor Shaddam sees as a potential threat to his rule. Shaddam's plan is to give House Atreides control of the planet Arrakis (also known as Dune), the only source of spice. Once they are installed on Arrakis, he intends to have them ambushed by their longtime archenemies, the Harkonnens, with assistance from the Emperor's elite troops, the Sardaukar. The Guild Navigator also commands the Emperor to kill Duke Leto's son, Paul Atreides, a young man who dreams prophetic visions of his purpose. The execution order draws the attention of the Bene Gesserit sisterhood, as Paul is tied to its centuries-long Bene Gesserit breeding program which seeks to produce the universe's superbeing, the Kwisatz Haderach. Before he leaves for Arrakis, Paul is tested by the Bene Gesserit Reverend Mother Mohiam by being forced to place his hand in a box which induces excruciating pain. To Mohiam's surprise and eventual satisfaction, he passes the test.",
+          "context_id": "ceb22d50445f4a33b0346f8bde198e2ba7f070fb",
+          "qas": [
+            {
+              "question": "What is the colloquial term for what allows the folding of space?",
+              "id": "94932ffe3b178a5ddb7a85164b225a6d8c234b6e",
+              "answers": [
+                {
+                  "text": "the spice",
+                  "answer_start": 159
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person that the Sardaukar serve?",
+              "id": "5ace72c92c5d99ef974187c8c1f67cef3e3e6f05",
+              "answers": [
+                {
+                  "text": "Shaddam",
+                  "answer_start": 745
+                }
+              ]
+            },
+            {
+              "question": "What's the full name of the heir of House Atreides?",
+              "id": "2df06e3981902fa6ac69167ff6c069e0a2040b48",
+              "answers": [
+                {
+                  "text": "Paul Atreides",
+                  "answer_start": 1163
+                }
+              ]
+            },
+            {
+              "question": "What's the first name of the person Duke Leto's heir satisfies?",
+              "id": "637d3c40d711b3c5bc5470d2ea43293373f7af78",
+              "answers": [
+                {
+                  "text": "Mohiam",
+                  "answer_start": 1531
+                }
+              ]
+            },
+            {
+              "question": "What is the alternate name of the place where the substance that extends life comes from?",
+              "id": "5f11d952b90528e4543599072ccf8dc9d8120d7a",
+              "answers": [
+                {
+                  "text": "Dune",
+                  "answer_start": 879
+                }
+              ]
+            },
+            {
+              "question": "What organization tests Duke Leto's son?",
+              "id": "10131a7423da2f7c24be0957a8868a1241a250e5",
+              "answers": [
+                {
+                  "text": "the Bene Gesserit sisterhood",
+                  "answer_start": 1278
+                }
+              ]
+            },
+            {
+              "question": "What is Mother Mohiam's organization trying to create?",
+              "id": "7b01c90f4b8f06b1817e5ebfe66d72597505e2d9",
+              "answers": [
+                {
+                  "text": "the Kwisatz Haderach",
+                  "answer_start": 1427
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Confederate government of Kentucky",
+      "url": "https://en.wikipedia.org/wiki/Confederate_government_of_Kentucky",
+      "paragraphs": [
+        {
+          "context": "The Confederate government of Kentucky was a shadow government established for the Commonwealth of Kentucky by a self-constituted group of Confederate sympathizers during the American Civil War. The shadow government never replaced the elected government in Frankfort, which had strong Union sympathies. Neither was it able to gain the whole support of Kentucky's citizens; its jurisdiction extended only as far as Confederate battle lines in the Commonwealth. Nevertheless, the provisional government was recognized by the Confederate States of America, and Kentucky was admitted to the Confederacy on December 10, 1861. Kentucky was represented by the central star on the Confederate battle flag.Bowling Green, Kentucky, was designated the Confederate capital of Kentucky at a convention in nearby Russellville. Due to the military situation in the state, the provisional government was exiled and traveled with the Army of Tennessee for most of its existence. For a short time in the autumn of 1862, the Confederate Army controlled Frankfort, the only time a Union capital was captured by Confederate forces. During this occupation, General Braxton Bragg attempted to install the provisional government as the permanent authority in the Commonwealth. However, Union General Don Carlos Buell ambushed the inauguration ceremony and drove the provisional government from the state for the final time. From that point forward, the government existed primarily on paper and was dissolved at the end of the war.\nThe provisional government elected two governors. George W. Johnson was elected at the Russellville Convention and served until his death at the Battle of Shiloh. Richard Hawes was elected to replace Johnson and served through the remainder of the war.",
+          "context_id": "ece5628646fa29f6b4f3e451a0a6cdcab465c9fc",
+          "qas": [
+            {
+              "question": "What never replaced the elected government in Frankfort?",
+              "id": "6696176022c65fc7386e746ce1d03c6232c439ab",
+              "answers": [
+                {
+                  "text": "The Confederate government of Kentucky",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What are the full names of the two governors that the provisional government elected?",
+              "id": "fb1a71a9834ff6d785fac6a5fa2ba3c4b824152e",
+              "answers": [
+                {
+                  "text": "George W. Johnson",
+                  "answer_start": 1559
+                },
+                {
+                  "text": "Richard Hawes",
+                  "answer_start": 1672
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "Kentucky's citizens were split regarding the issues central to the Civil War. The state had strong economic ties with Ohio River cities such as Pittsburgh and Cincinnati while at the same time sharing many cultural, social, and economic links with the South. Unionist traditions were strong throughout the Commonwealth's history, especially in the east. With economic ties to both the North and the South, Kentucky had little to gain and much to lose from a war between the states. Additionally, many slaveholders felt that the best protection for slavery was within the Union.\nThe presidential election of 1860 showed Kentucky's mixed sentiments when the state gave John Bell 45% of the popular vote, John C. Breckinridge 36%, Stephen Douglas 18%, and Abraham Lincoln less than 1%. Historian Allan Nevins interpreted the election results to mean that Kentuckians strongly opposed both secession and coercion against the secessionists. The majority coalition of Bell and Douglas supporters was seen as a solid moderate Unionist position that opposed precipitate action by extremists on either side.\nThese elections demonstrated that a majority of the people of Kentucky were opposed to secession, but they could not be interpreted as an approval of the war policy of the Lincoln administration, as was quite generally done at the north at that time. Perhaps the best explanation at that time was that the people of Kentucky desired peace and thought that the election of the union candidates was the best way to get it.\nWith secession no longer considered a viable option, the pro-Confederate forces became the strongest supporters for neutrality. Unionists dismissed this as a front for a secessionist agenda. Unionists, on the other hand, struggled to find a way to move the large, moderate middle to a \"definite and unqualified stand with the Washington government.\" The maneuvering between the two reached a decisive point on September 3 when Confederate forces were ordered from Tennessee to the Kentucky towns of Hickman and Columbus. Union forces responded by occupying Paducah.On September 11, the legislature passed a resolution instructing Magoffin to order the Confederate forces (but not the Union forces) to leave the state. The Governor vetoed the resolution, but the General Assembly overrode his veto, and Magoffin gave the order. The next week, the assembly officially requested the assistance of the Union and asked the governor to call out the state militia to join the Federal forces. Magoffin also vetoed this request. Again the assembly overrode his veto and Magoffin acquiesced.",
+          "context_id": "65c4e57384b3fdbd4687a826c4c2f89d246dcaae",
+          "qas": [
+            {
+              "question": "What place had strong ties with Cincinnati and Pittsburgh?",
+              "id": "1702ea61ec5bf9e7ee611c6553d5895a0c3bc864",
+              "answers": [
+                {
+                  "text": "Kentucky",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What are the first names of the two men who had a majority coalition of supporters?",
+              "id": "a38076bae4e022a41232bc3a41de7c570a9a7154",
+              "answers": [
+                {
+                  "text": "John",
+                  "answer_start": 667
+                },
+                {
+                  "text": "Stephen",
+                  "answer_start": 728
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "Prior to abandoning Bowling Green, Governor Johnson requested that Richard Hawes come to the city and help with the administration of the government, but Hawes was delayed due to a bout with typhoid fever. Following Johnson's death, the provisional government elected Hawes, who was still recovering from his illness, as governor. Following his recovery, Hawes joined the government in Corinth, Mississippi, and took the oath of office on May 31.During the summer of 1862, word began to spread through the Army of Tennessee that Generals Bragg and Edmund Kirby Smith were planning an invasion of Kentucky. The legislative council voted to endorse the invasion plan, and on August 27, Governor Hawes was dispatched to Richmond to favorably recommend it to President Davis. Davis was non-committal, but Bragg and Smith proceeded, nonetheless.On August 30, Smith commanded one of the most complete Confederate victories of the war against an inexperienced Union force at the Battle of Richmond. Bragg also won a decisive victory at the September 13 Battle of Munfordville, but the delay there cost him the larger prize of Louisville, which Don Carlos Buell moved to occupy on September 25. Having lost Louisville, Bragg spread his troops into defensive postures in the central Kentucky cities of Bardstown, Shelbyville and Danville and waited for something to happen, a move that historian Kenneth W. Noe called a \"stupendously illogical decision.\"Meanwhile, the leaders of Kentucky's Confederate government had remained in Chattanooga, Tennessee, awaiting Governor Hawes' return. They finally departed on September 18, and caught up with Bragg and Smith in Lexington, Kentucky on October 2. Bragg had been disappointed with the number of soldiers volunteering for Confederate service in Kentucky; wagon loads of weapons that had been shipped to the Commonwealth to arm the expected enlistees remained unissued. Desiring to enforce the Confederate Conscription Act to boost recruitment, Bragg decided to install the provisional government in the recently captured state capital of Frankfort. On October 4, 1862, Hawes was inaugurated as governor by the Confederate legislative council. In the celebratory atmosphere of the inauguration ceremony, however, the Confederate forces let their guard down, and were ambushed and forced to retreat by Buell's artillery.",
+          "context_id": "07cfa575bd4e20bbe7383f834106e80eec407f68",
+          "qas": [
+            {
+              "question": "What is the first name of the person who was delayed due to a bout with typhoid fever?",
+              "id": "4411d714dcbe24140db1850cd772b04a99872a83",
+              "answers": [
+                {
+                  "text": "Richard",
+                  "answer_start": 67
+                }
+              ]
+            },
+            {
+              "question": "What was the first name of the person who replaced Governor Johnson?",
+              "id": "ace8eed5f9e939282903f8dfa0f4fe4dcded7d52",
+              "answers": [
+                {
+                  "text": "Richard",
+                  "answer_start": 67
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who was cost the larger prize of Louisville due to delays?",
+              "id": "c47d2e53c25353ad69525f4365f842fe894b2429",
+              "answers": [
+                {
+                  "text": "Bragg",
+                  "answer_start": 801
+                }
+              ]
+            },
+            {
+              "question": "In what state did the Confederate recently capture Frankfort?",
+              "id": "09c10c20d0f2e13dc6daa087518b55a23879c91e",
+              "answers": [
+                {
+                  "text": "Kentucky",
+                  "answer_start": 1785
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "Following the Battle of Perryville, the provisional government left Kentucky for the final time. Displaced from their home state, members of the legislative council dispersed to places where they could make a living or be supported by relatives until Governor Hawes called them into session. Scant records show that on December 30, 1862, Hawes summoned the council, auditor, and treasurer to his location at Athens, Tennessee for a meeting on January 15, 1863. Hawes himself unsuccessfully lobbied President Davis to remove Hawes' former superior, Humphrey Marshall, from command. On March 4, Hawes told Davis by letter that \"our cause is steadily on the increase\" and assured him that another foray into the Commonwealth would produce better results than the first had.The government's financial woes also continued. Hawes was embarrassed to admit that neither he nor anyone else seemed to know what became of approximately $45,000 that had been sent from Columbus to Memphis, Tennessee during the Confederate occupation of Kentucky. Another major blow was Davis' 1864 decision not to allow Hawes to spend $1 million that had been secretly appropriated in August 1861 to help Kentucky maintain its neutrality. Davis reasoned that the money could not be spent for its intended purpose, since Kentucky had already been admitted to the Confederacy.Late in the war, the provisional government existed mostly on paper. However, in the summer of 1864, Colonel R. A. Alston of the Ninth Tennessee Cavalry requested Governor Hawes' assistance in investigating crimes allegedly committed by Brigadier General John Hunt Morgan during his latest raid into Kentucky. Hawes never had to act on the request, however, as Morgan was suspended from command on August 10 and killed by Union troops on September 4, 1864.There is no documentation detailing exactly when Kentucky's provisional government ceased operation. It is assumed to have dissolved upon the conclusion of the Civil War.",
+          "context_id": "c22f8c4c95e87c4ddf0b551736e94937f8dd181e",
+          "qas": [
+            {
+              "question": "What is the last name of the person who was assured that another foray into the Commonwealth would produce better results than the first?",
+              "id": "0c8b7ff9a2f148220924694b7c624377cb77bb26",
+              "answers": [
+                {
+                  "text": "Davis",
+                  "answer_start": 604
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Black Bird",
+      "url": "https://en.wikipedia.org/wiki/The_Black_Bird",
+      "paragraphs": [
+        {
+          "context": "When San Francisco private detective Sam Spade dies, his son, Sam, Jr., inherits his father's agency, including the sarcastic secretary, Effie Perine (also known as \"Godzilla\").  He must also continue his father's tradition of \"serving minorities.\" When Caspar Gutman is killed outside Spade's building, his dying words are, \"It's black and as long as your arm.\"\nSpade is given an offer by a member of the Order of St. John's Hospital to purchase his father's useless copy of the Maltese Falcon. A right-wing thug named Gordon Immerman has been hired to make sure Spade delivers the bird.  He later gets an offer from Wilmer Cook for the Falcon, but before they can negotiate, he is killed. Shortly thereafter he meets a beautiful and mysterious Russian woman named Anna Kemidov, daughter of the general who once owned the real Maltese Falcon. She also wants Spade's copy and is willing to seduce him to get it. Spade is soon dealing with Litvak, a bald Nazi dwarf who is surrounded by an army of Hawaiian thugs. In the ensuing chaos, Immerman tries to become Spade's partner. Spade discovers that his \"false\" copy may be the real thing.",
+          "context_id": "4fd9b3cd0079f081234e34ebba0b34a11c562707",
+          "qas": [
+            {
+              "question": "What is the name of the person Effie worked for first? ",
+              "id": "6d3533feb42015757252b3ee2f69f76e450401e3",
+              "answers": [
+                {
+                  "text": "Sam Spade",
+                  "answer_start": 37
+                }
+              ]
+            },
+            {
+              "question": "Who is killed before negotiations can start for the Maltese Falcon?",
+              "id": "2e37d58f15dbeb7f35e2849c4c879a62c94c24e8",
+              "answers": [
+                {
+                  "text": "Wilmer Cook",
+                  "answer_start": 618
+                }
+              ]
+            },
+            {
+              "question": "What is the alias of the secretary? ",
+              "id": "13d72a32c2897980ef4513a7eb4ada099cfaacf5",
+              "answers": [
+                {
+                  "text": "Godzilla",
+                  "answer_start": 166
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who met Anna?",
+              "id": "b1757cd366b92990c566c8d348d1053f9c6819cc",
+              "answers": [
+                {
+                  "text": "Spade",
+                  "answer_start": 41
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who tries to become Spade's partner? ",
+              "id": "7617ac386c4d90f9e0211843ba13d00e018e3bb1",
+              "answers": [
+                {
+                  "text": "Gordon",
+                  "answer_start": 520
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the character who owned a copy of the Maltese Falcon first?",
+              "id": "2b6fd4a79181b3917987123d9a15f3127ecb7dc1",
+              "answers": [
+                {
+                  "text": "Sam Spade",
+                  "answer_start": 37
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Flight to Hong Kong",
+      "url": "https://en.wikipedia.org/wiki/Flight_to_Hong_Kong",
+      "paragraphs": [
+        {
+          "context": "International smuggler Tony Dumont is aboard a plane carrying a shipment of industrial diamonds. It is hijacked by men who flee with the gems. Tony and other passengers, including famed author Pamela Vincent, are flown to Hong Kong, where he doesn't get to say goodbye because Pamela is mobbed by the press.\nIt turns out Tony was mastermind of the heist. He goes to Macao to see girlfriend Jean Blake and old friend Michael Quisto. They go to the nightclub run by Mama Lin, who raised Tony as an orphan. Pamela is among the club's customers that night, so they renew their acquaintance.\nJean is angered by Tony abandoning her at the club. He took off with henchmen Nicco and Boris to get the diamonds, but they are ambushed. Tony is told that Quisto was the snitch who betrayed them. Ordered by boss Bendesh to kill the informer, Tony hesitates, but Quisto stumbles off a gangplank into a boat's netting and is dragged to his death.\nTony becomes romantically involved with Pamela, so Jean breaks off their relationship. Upset by his friend's death, Tony wants to reform and get out of the business. He travels to San Francisco to find Pamela, only to learn she has written a new book with a character based on him, and now wants nothing more to do with him, having taken up with a tennis player.\nJean and Mama Lin try to help Tony settle matters with his former accomplices, but accidentally lead him into Nicco's trap. The police arrive in time to take Tony and Nicco into custody, leaving the women by themselves, wondering what's to become of Tony.",
+          "context_id": "0a3208cd9b9eb35ad2a9fe331a7801b0a988bede",
+          "qas": [
+            {
+              "question": "What is the first name of the informer?",
+              "id": "389ab9da4c060b8dc1bb043c81cca73c30f08a7e",
+              "answers": [
+                {
+                  "text": "Michael",
+                  "answer_start": 416
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person that goes to San Francisco to find Pamela?",
+              "id": "f271a5e0bd69ca42751b72f82f99899cd38e42db",
+              "answers": [
+                {
+                  "text": "Tony Dumont",
+                  "answer_start": 23
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who is dating Jean Blake?",
+              "id": "a6eeaf716de13c4daef32aaa159bb753ac035a3f",
+              "answers": [
+                {
+                  "text": "Tony",
+                  "answer_start": 321
+                }
+              ]
+            },
+            {
+              "question": "What are the full names of the people who go to the nightclub run by Mama Lin?",
+              "id": "bafe25e690850dac28e234da90f564d6fa0e084b",
+              "answers": [
+                {
+                  "text": "Tony Dumont",
+                  "answer_start": 23
+                },
+                {
+                  "text": "Jean Blake",
+                  "answer_start": 390
+                },
+                {
+                  "text": "Michael Quisto",
+                  "answer_start": 416
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who renews their acquaintance with Pamela?",
+              "id": "91ba7c9c69a5a8b124322d6d4b9f803b4428c5d6",
+              "answers": [
+                {
+                  "text": "Tony",
+                  "answer_start": 321
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person whose death Tony is upset by?",
+              "id": "2815f2bbc5f40db66f934468d5493e1c2f931bce",
+              "answers": [
+                {
+                  "text": "Michael",
+                  "answer_start": 416
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Internal Affairs (film)",
+      "url": "https://en.wikipedia.org/wiki/Internal_Affairs_(film)",
+      "paragraphs": [
+        {
+          "context": "During a drug bust, LAPD patrolmen Dennis Peck and Van Stretch assault a dealer and his girlfriend. Outside, fellow patrolman Dorian Fletcher shoots a man running towards him, only to discover that he was unarmed. While Fletcher is distraught by the incident, Peck plants a knife on the body to get Fletcher off the hook. Soon afterwards, Raymond Avila joins the LAPD's Internal Affairs Division and is assigned to investigate the drug bust with partner Amy Wallace.\nThe investigation reveals that Stretch abuses drugs, has a history of excessive force, and may be corrupt. Avila eventually begins to look into Peck, who is held up as a role model for the LAPD but is regarded with distaste by other officers over his brutal techniques and has a lifestyle (including paying spousal support for a string of ex-wives) that is hard to justify with a patrolman's salary alone. Avila unsuccessfully pressures Stretch to provide evidence against Peck in return for immunity from prosecution. Fletcher, who has gotten into an altercation with Peck, agrees to help Avila's investigation. Avila's marriage starts to wilt due to his increased obsession with the case, and Peck insinuates he will make advances on Avila's wife, Kathleen.\nWhen Stretch makes it known that he will testify, Peck (who is having an affair with Stretch's wife) resolves to have him murdered. During a routine patrol in Huntington Park, Stretch is shot through the chest in a hit staged by Peck. After Peck murders the hitman, he sees the blue van used in the hit speeding away, indicating a witness to the crime. When Stretch is revealed to be alive, Peck strangles him. Avila and Wallace set up a sting to catch the witness, but two SWAT units arrive on the scene after the sting is leaked. Fletcher and the witness are killed in the resulting shootout. As he dies in Avila's arms, he identifies Peck as Stretch's killer.",
+          "context_id": "4f23053ea90e60eb88dfdb32974afe314e8d821a",
+          "qas": [
+            {
+              "question": "What is the first name of the person that sees a blue van used in the hit speeding away?",
+              "id": "4ec1d01e4366d6eb7c360158e8abb4ca34c809ba",
+              "answers": [
+                {
+                  "text": "Dennis",
+                  "answer_start": 35
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Dollman vs. Demonic Toys",
+      "url": "https://en.wikipedia.org/wiki/Dollman_vs._Demonic_Toys",
+      "paragraphs": [
+        {
+          "context": "The film begins with Brick Bardo hitchhiking to get to the town of Pahoota, where he tries to find a girl named Nurse Ginger (Melissa Behr, who was shrunken to 11 inches in Bad Channels), to prove to her that she is not alone. Meanwhile, the film cuts to Judith Grey, who has a nightmare about the events that happened in the previous film a year before. Ever since the events that took place a year before, Judith has been watching the Toyland Warehouse, believing that the toys are still alive. Meanwhile, a drunken bum enters the warehouse to shelter from the rain, and starts to mess around with a clown tricycle, until he gets knocked in the head with a box of toys, causing him to hit his head on the ground, killing him. However, his blood continues to flow over to the place where the demon was buried, and brings back: Baby Oopsy Daisy, Jack Attack, and Mr. Static, but Grizzly Teddy is replaced by a new toy named Zombietoid - a blonde GI Joe action figure with a sword as a weapon.\nJudith, who's now inside the building, sees the toys in full view, but is then arrested for breaking into a secluded building while serving out a suspension. After the police leave, the toys force the new security guard Ray Vernon to help them with their needs. Ginger who spends her time on a kitchen counter all alone is being harassed by a sleazy reporter for an interview and so she reluctantly agrees to one so he'll leave her in peace. After he leaves, a big spider appears and as Ginger screams, Brick suddenly shows up and shoots it dead. Then a surprised Ginger asks Brick how he's so tiny like her, which results in both characters recapping their stories. Although Ginger explains that it's herself who's been left at a doll sized height by aliens, instead of Bunny, which was what occurred in the actual story of Bad Channels.",
+          "context_id": "e77efd30a6c8ad3565ffaaf708a728302af88e85",
+          "qas": [
+            {
+              "question": "Who agrees to an interview?",
+              "id": "bf058978821e359c6f08261f8efa9ac9802afaba",
+              "answers": [
+                {
+                  "text": "Ginger",
+                  "answer_start": 1255
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who spends her time on the kitchen counter?",
+              "id": "7ee35fccda450e99794deaf14ff75f39a6fcee1c",
+              "answers": [
+                {
+                  "text": "Ginger",
+                  "answer_start": 1255
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "For Richer or Poorer",
+      "url": "https://en.wikipedia.org/wiki/For_Richer_or_Poorer",
+      "paragraphs": [
+        {
+          "context": "After ten years of marriage, New York City millionaire socialite couple Brad and Caroline Sexton are miserable and have decided to call it quits. Their marital problems come to a head earlier that evening when Brad turns their 10th anniversary party into a real estate development pitch for a theme park he calls \"The Holy Land\", modeled after Biblical lore. The pitch turns disastrous when one of the display's special effects catches a guest's (who happens to be a federal judge) dress on fire.\nAt the same time, Brad's accountant, Bob Lachman, is stealing the Sextons' millions through mismanagement and filing false tax returns. His money manipulation has caught the attention of the Internal Revenue Service, and field agent Frank Hall, demands to meet Bob and Brad the following morning to bring the obligations up to date and settle the missing $5,000,000.\nBob arrives at the office early the following morning with a file box (likely the incriminating paperwork that could land him in jail), but leaves before Brad arrives. Though he doesn't get out in time, he manages to finally evade Brad and Hall, who has just shown up.\nHearing a hint from Bob that the Sextons could be fleeing (Brad told him about the Sextons' impending divorce), Hall orders the freezing of all their assets. Brad is unable to access his money through an ATM and Caroline has her credit card destroyed at her table as she's having lunch with some friends. Brad is then informed that his accounts have been frozen, but the bank teller refuses to tell him why. At first he thinks Caroline is responsible, until he gets Bob on the phone, who tells him that he himself is the cause of their newfound problems as he's headed for the airport.",
+          "context_id": "2308f1684743d29b3d810bd3321d483ddf172214",
+          "qas": [
+            {
+              "question": "What is the full name of the person who leaves for the airport after explaining to Bob the reason for their newest problems?",
+              "id": "899d02ea2de744fd47e85c41b8bbe842a04794f1",
+              "answers": [
+                {
+                  "text": "Bob Lachman",
+                  "answer_start": 534
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the character who manages to evade Brad and field agent Hall?",
+              "id": "79b5635727eecf8eb0ff67828537db0f8171275d",
+              "answers": [
+                {
+                  "text": "Bob Lachman",
+                  "answer_start": 534
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the character who Brad initially suspects of freezing his accounts?",
+              "id": "4f6020511cea1cf0c354db438935e6900d06d75d",
+              "answers": [
+                {
+                  "text": "Caroline Sexton",
+                  "answer_start": 81
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Under the Mud",
+      "url": "https://en.wikipedia.org/wiki/Under_the_Mud",
+      "paragraphs": [
+        {
+          "context": "The Potts family includes father Joe, mother Sally, teenagers Paul and Paula, young children Olivia and Karl, and the Potts's part-time lodger, Magic.\nOn the day of Olivia's Communion, the family is prepared for a large celebration, for which they have arranged a party in a local social club and ornamented Olivia with electrically powered angel wings.\nAs Joe gets drunk and his attempts to enliven the social atmosphere with jokes and banter fall flat, the cracks in the family's relationships are revealed: Sally wonders whether she is still beautiful or appreciated; Paula, who throughout the film talks out loud to and continually confers with her imaginary friend Georgina, worries over the news that her beloved boyfriend DJ Worm is planning to move to Ibiza without telling her; Magic tries to console her while suppressing his obvious attraction to Paula.\nWhen Paula is entrusted with taking Olivia and Karl back to the family home, the film takes more turns for the dramatic. Paula suspects she might be pregnant and desperately attempts to find DJ Worm. As Paula is out of the house, Olivia and Karl steal a car and go for a joyride. Magic becomes frustrated in his attempts to steer Paula towards level-headedness and find the missing children. At the social club, Joe and Sally find their relationship strained to the breaking point by both their own failure to communicate and by the charms of local gangster One Dig, who dated Sally years ago and is still willing to offer her a wedding ring.",
+          "context_id": "338b346a2ae74534ee11b05d9f66d30dac047c03",
+          "qas": [
+            {
+              "question": "Who are the parents of the child having communion?",
+              "id": "a42e321a963234b2abaa4a3eb6a4587df9be31c3",
+              "answers": [
+                {
+                  "text": "Joe",
+                  "answer_start": 33
+                },
+                {
+                  "text": "Sally",
+                  "answer_start": 45
+                }
+              ]
+            },
+            {
+              "question": "What is the occupation of the man who once dated Olivia's mother?",
+              "id": "48ea39c2c988f1e6f5e7188c50a4e3acc6d6c164",
+              "answers": [
+                {
+                  "text": "gangster",
+                  "answer_start": 1414
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who wants to propose to Karl's mother?",
+              "id": "835d47d567a5130742ccaa798169ff78a22f2be4",
+              "answers": [
+                {
+                  "text": "One Dig",
+                  "answer_start": 1423
+                }
+              ]
+            },
+            {
+              "question": "Who are the four children of the man who gets drunk?",
+              "id": "fe071c581918933813a726b00f13cdca666c1038",
+              "answers": [
+                {
+                  "text": "Paul",
+                  "answer_start": 62
+                },
+                {
+                  "text": "Paula",
+                  "answer_start": 71
+                },
+                {
+                  "text": "Olivia",
+                  "answer_start": 93
+                },
+                {
+                  "text": "Karl",
+                  "answer_start": 104
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Ambohimanga",
+      "url": "https://en.wikipedia.org/wiki/Ambohimanga",
+      "paragraphs": [
+        {
+          "context": "Ambohimanga is a hill and traditional fortified royal settlement (rova) in Madagascar, located approximately 24 kilometers (15 mi) northeast of the capital city of Antananarivo. The hill and the rova that stands on top are considered the most significant symbol of the cultural identity of the Merina people and the most important and best-preserved monument of the precolonial Merina Kingdom. The walled historic village includes residences and burial sites of several key monarchs. The site, one of the twelve sacred hills of Imerina, is associated with strong feelings of national identity and has maintained its spiritual and sacred character both in ritual practice and the popular imagination for at least four hundred years. It remains a place of worship to which pilgrims come from Madagascar and elsewhere.\nThe site has been politically important since the early 18th century, when King Andriamasinavalona (1675\u20131710) divided the Kingdom of Imerina into four quadrants and assigned his son Andriantsimitoviaminiandriana to govern the northeastern quadrant, Avaradrano, from its newly designated capital at Ambohimanga. The division of Imerina led to 77 years of civil war, during which time the successive rulers of Avaradrano led military campaigns to expand their territory while undertaking modifications to the defenses at Ambohimanga to better protect it against attacks. The war was ended from Ambohimanga by King Andrianampoinimerina, who successfully undertook negotiations and military campaigns that reunited Imerina under his rule by 1793. Upon capturing the historic capital of Imerina at Antananarivo, Andrianampoinimerina shifted his royal court and all political functions back to its original locus at Antananarivo's royal compound and declared the two cities of equal importance, with Ambohimanga as the kingdom's spiritual capital. He and later rulers in his line continued to conduct royal rituals at the site and regularly inhabited and remodeled Ambohimanga until French colonization of the kingdom and the exile of the royal family in 1897. The significance of historical events here and the presence of royal tombs have given the hill a sacred character that is further enhanced at Ambohimanga by the burial sites of several Vazimba, the island's earliest inhabitants.",
+          "context_id": "8a09034f8b93d5d67d3e78d6b36438a88f9121af",
+          "qas": [
+            {
+              "question": "Who remodeled Ambohimanga?",
+              "id": "850fa91808dfd385885a814b703600de2c4f103d",
+              "answers": [
+                {
+                  "text": "Andrianampoinimerina",
+                  "answer_start": 1624
+                }
+              ]
+            },
+            {
+              "question": "Who regularly inhabited the site?",
+              "id": "6c8b7c88cd8cb28cf897b82ba4871a92a8cc3856",
+              "answers": [
+                {
+                  "text": "Andrianampoinimerina",
+                  "answer_start": 1624
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "Following the conquest of Antananarivo in 1793, Andrianampoinimerina shifted the political capital of Imerina from Ambohimanga to its original site at Antananarivo, while pronouncing Ambohimanga the kingdom's spiritual capital. Important traditional rituals continued to be held at Ambohimanga, and Andrianampoinimerina regularly stayed in its Mahandrihono palace. His son, Radama I, inhabited Ambohimanga's Nanjakana compound as a youth before relocating to Antananarivo, and visited Ambohimanga frequently after the move. Radama's widow and successor, Ranavalona I, renovated the Mahandrihono compound and moved several buildings from the sister rova at Antananarivo to Ambohimanga. She also forbade swine at Ambohimanga due to their association with Europeans, who had propagated pork as a food source in the decade prior. Subsequent queens made their own mark on the site, including the reconstruction of Nanjakana by Rasoherina, and Ranavalona II's addition of two large pavilions to the Mahandrihono compound that reflected a syncretism of traditional and Western architectural styles.Throughout much of the 19th century and particularly under the reign of Queen Ranavalona I (1828\u20131861), Ambohimanga was forbidden to visiting foreigners, contributing to its mystique as a \"forbidden city\". This status remained until 1897 when the French colonial administration transferred all the relics and significant belongings of the royal family from Ambohimanga to Antananarivo to break the spirit of resistance and ethnic identity that these symbols inspired in the Malagasy people, particularly in the highlands. In the early 20th century, the area was further changed when the French removed the sacred forests remaining on the neighboring hilltops in the early 20th century. The city nonetheless retains its symbolic significance in Imerina to this day.",
+          "context_id": "ab19f9d479e2f654764391318478f3340cc46e64",
+          "qas": [
+            {
+              "question": "Whose son inhabited Nanjakana compound as a youth?",
+              "id": "391ed2bef042f46b22e04e1bf1641982877ee0f1",
+              "answers": [
+                {
+                  "text": "Andrianampoinimerina",
+                  "answer_start": 48
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "The royal compound can be accessed through fourteen stone gateways in total. In addition to the inner seven gateways constructed by Andriantsimitoviaminiandriana in the early 18th century, there exists an exterior wall and second set of seven gates that were built before 1794 during the reign of Andrianampoinimerina, an act that symbolically marked the completion of the king's reunification of Imerina. The largest and principal gate is also the most well-preserved and is known as Ambatomitsangana (\"standing stone\").  Every morning and evening, a team of twenty soldiers would work together to roll into place an enormous stone disk, 40.5 meters in diameter and 30 cm thick, weighing about 12 tons, to open or seal off the doorway. This form of gate (vavahady in the Malagasy language), typical of most walled royal villages of Imerina built between 1525 and 1897, protected the villagers from marauders.The gateway is topped by an observation post. The second main entrance, called Andakana, is situated in the western wall. Its stone disk is also intact, and the path leading to it is paved with cut stones. Both Ambatomitsangana and Andakana were considered the gateways of the living; cadavers could not be transported through them, and passage was denied to anyone who had recently come into contact with the dead.  A northern gateway called Miandrivahiny retains its well-preserved stone disk and was one of two entrances used whenever it was necessary to transport corpses in or out of the site; the second gateway for corpses was called Amboara. The stone disk at the southern Andranomatsatso gateway is also in good condition. This gateway, as well as Antsolatra and Ampitsaharana, were primarily used as lookout points. In the late 18th century Andrianampoinimerina replaced the Ambavahadiantandranomasina gate with another made of wood instead of stone and renamed it Ambavahadimasina. He and his successors shaved a small piece of wood from this lintel to light the sacred hearth fire that played a ritual role in the traditional circumcision ceremony. The red soil inside the gate and a series of wooden boards that paneled the approach to the gate were both considered sacred, and soldiers or others who anticipated a voyage away from Imerina would take handfuls of the soil and pieces of the wooden boards with them before departing in the belief that it would ensure their safe return.Several large stones are set in the ground near gates or at points outside the walls of Ambohimanga. Rulers would stand atop these stones, each identified by distinct names, to deliver speeches to the public. To the south were the stones called Ambatomasina and Ambatomenaloha, while Ambatorangotina was situated to the northwest. The latter stone was of particular importance: here the twelve leaders of the Ambatofotsy clan first declared their rejection of Andrianjafy's rule and their allegiance to his nephew, Andrianampoinimerina. Upon taking the throne, Andrianampoinimerina used this site to first declare new laws and decrees that would later be announced throughout the kingdom. This was also the main site at Ambohimanga for dispensing justice. After Andrianampoinimerina's succession to the throne, he sacrificed a black zebu whose mother had died, named Lemainty (\"black one\"), with repeated spear thrusts; after its death, the animal was cut into pieces and buried on the site. Lemainty was thereafter regularly invoked in royal speeches and decrees to allude to the fate of those who misguidedly sought to forsake the protection of their guardian, the sovereign, and his laws.",
+          "context_id": "d4e0883f4b84086cf87c7255c4312ae1b71c8925",
+          "qas": [
+            {
+              "question": "What is the name of the gateway that, along with Antsolatra and Ampitsaharana, was primarily used as a lookout point?",
+              "id": "2d694673b56f75ac91c2458d956195df73095e9c",
+              "answers": [
+                {
+                  "text": "Andranomatsatso",
+                  "answer_start": 1590
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the stone whose particular importance derives from being the location where the twelve leaders of the Ambatofotsy clan first declared their rejection of Andrianjafy's rule and their allegiance to his nephew, Andrianampoinimerina? ",
+              "id": "f64eba0b1108283e5b7b2692b40901735fb4b5a0",
+              "answers": [
+                {
+                  "text": "Ambatorangotina",
+                  "answer_start": 2690
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "Among the buildings extant at the royal city during the time of King Andrianampoinimerina (1787\u20131810), only the original Mahandrihono palace remains intact. The Mahandrihono palace, which served as the home of Andrianampoinimerina before he relocated the political capital of Imerina to Antananarivo, has been preserved in its original state since construction, excepting the replacement of the original roof thatch with wooden shingles. The simple wooden structure is constructed in the traditional style of the aristocracy of Imerina: the walls are made of solid rosewood and topped by a peaked roof that is supported by 10-meter central rosewood pillar, much like the one that had originally supported the roof of the Rova Manjakamiadana of Antananarivo before it was destroyed by fire in 1995. The roof horns (tandrotrano) formed at each end of the roof peak by the crossing of the gable beams were originally silver-plated, and a silver eagle was affixed in the middle of the roof peak. Silver ornaments were also hung from the corners of the roof in the interior of the house. The building's name is inscribed on a white marble plaque affixed to an exterior wall near one of the building's two entrances. This house contains a number of items that belonged to Andrianampoinimerina, including weapons, drums, talismans and a bed raised on stilts. During Andrianampoinimerina's time, his wives were allowed to visit this building but not allowed to sleep there overnight. The site is highly sacred: Queen Rasoherina and her successors often sat on the stepping stone at its threshold to address their audience, and many pilgrims come here to connect with the spirits of Andrianampoinimerina and his ancestors. Visitors are asked to enter the house by stepping in with their right foot and exiting backwards, according to custom, in order to show respect for the spirit of Andrianampoinimerina.",
+          "context_id": "fdb5b25b8f3ff553b50cdf2a542d0f2b07b0a734",
+          "qas": [
+            {
+              "question": "What is the name of the royal who sat at the steps of the building to address the audience were the wives of the king were not allowed to sleep?",
+              "id": "1b8042d4f013aad8c9487679fc4069bb496cabbc",
+              "answers": [
+                {
+                  "text": "Rasoherina",
+                  "answer_start": 1509
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Daybreak in Udi",
+      "url": "https://en.wikipedia.org/wiki/Daybreak_in_Udi",
+      "paragraphs": [
+        {
+          "context": "It is 1949, and colonial Nigeria is undergoing an identity crisis. There is a clash between the progressive, educated elements of society - those who desire westernization and modernity- and traditionalists who want to maintain Nigerian heritage. Two young African teachers, Iruka and Dominic decide the village of Udi should have a maternity home, itself a symbol of progressiveness and modernization. The British District Officer, E.R. Chadwick, after some persuasion, assents to this decision and agrees to provide the resources for the project. Before work can begin, Chadwick wants to ensure that everyone in the village is on board for the task, but it quickly becomes clear that this is not the case. A man named Eze, an elderly resident, believes that building the maternity home is both an affront to the tradition and culture of the village, and works to persuade others towards his view.\nChadwick visits the village in an attempt to convince the villagers otherwise, a task in which he ultimately succeeds. Work on the maternity home begins in earnest. Although it will prove a long, arduous process, the villagers band together to construct the building. They are interrupted by Eze, who arrives at the building site and claims that it is an old burial ground. He predicts that the builders will invoke the ire of the ancestors for disturbing the site and violating custom. Cultural values quickly manifest. Fear and superstition briefly stop the work, but Chadwick and Dominic arrive to allay the workers' fears and restart the building project. However, Eze's threat looms large in the back of their minds.",
+          "context_id": "089786bf651941eabbc7b32079444c2637e7876f",
+          "qas": [
+            {
+              "question": "What is the last name of the person that the two young African teachers persuade?",
+              "id": "c1fe24c850e81669fd65f8bbdb6fba4373526757",
+              "answers": [
+                {
+                  "text": "Chadwick",
+                  "answer_start": 438
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "\"One Tree Hill\" (song) 0",
+      "url": "https://en.wikipedia.org/wiki/One_Tree_Hill_(song)",
+      "paragraphs": [
+        {
+          "context": "\"One Tree Hill\" is a song by Irish rock band U2 and the ninth track on their 1987 album The Joshua Tree. In March 1988, it was released as the fourth single from the album in New Zealand and Australia, while \"In God's Country\" was released as the fourth single in North America. The release charted at number one on the New Zealand Singles Chart.\nThe track was written in memory of Greg Carroll, a M\u0101ori man the band first met in Auckland during the Unforgettable Fire Tour in 1984. He became very close friends with lead singer Bono and later served as a roadie for the group. Carroll was killed in July 1986 in a motorcycle accident in Dublin. Following the tangi funeral in New Zealand, Bono wrote the lyrics to \"One Tree Hill\" in Carroll's memory. The lyrics reflect Bono's thoughts at the tangi and during his first night in New Zealand when Carroll took him up Auckland's One Tree Hill. They also pay homage to Chilean singer-songwriter and activist V\u00edctor Jara. Musically, the song was developed in a jam session with producer Brian Eno. The vocals were recorded in a single take, as Bono felt incapable of singing them a second time.\n\"One Tree Hill\" was received favourably by critics, who variously described it as \"a soft, haunting benediction\", \"a remarkable musical centrepiece\", and a celebration of life. U2 delayed performing the song on the Joshua Tree Tour in 1987 because of Bono's fears over his emotional state. After its live debut on the tour's third leg and an enthusiastic reaction from audiences, the song was played occasionally for the rest of the tour and semi-regularly during the Lovetown Tour of 1989\u20131990. It has appeared only sporadically since then, and most renditions were performed in New Zealand. Performances in November 2010 on the U2 360\u00b0 Tour were dedicated to the miners who died in the Pike River Mine disaster. During the Joshua Tree Tour 2017 to commemorate the 30th anniversary of the album, \"One Tree Hill\" was performed at each show.",
+          "context_id": "c6ec2b12877388b5e09b8d7be84674b1f8ba62af",
+          "qas": [
+            {
+              "question": "What was the last name of the person who served as a roadie for U2?",
+              "id": "0608c05b35acf136a69e66b88922f3243d1fb47b",
+              "answers": [
+                {
+                  "text": "Carroll",
+                  "answer_start": 387
+                }
+              ]
+            },
+            {
+              "question": "What was the name of the tour where One Tree Hill was performed at each show?",
+              "id": "f9fbba1f3232318dec49eee76f39cc7649ef2681",
+              "answers": [
+                {
+                  "text": "Joshua Tree Tour 2017",
+                  "answer_start": 1867
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Cheech & Chong's Animated Movie",
+      "url": "https://en.wikipedia.org/wiki/Cheech_%26_Chong%27s_Animated_Movie",
+      "paragraphs": [
+        {
+          "context": "The movie opens with an interview with a body crab named Buster living on a bikini-clad woman. The body crab sees Man passing by and jumps on his beard. Man quickly pulls him out and throws him away. Pedro De Pacas is shown driving just up the street from the hitchhiking Man. Pedro sees him and stops the car to give Man a ride. Man gets in and they both peel off, sending the body crab flying. The body crab smells the strong marijuana scent left behind from their car and gives chase. Pedro and Man smoke a joint together and drive through traffic as Pedro admires the street lights. A police car suddenly appears from behind and tails them. Man quickly decides to eat all the drugs in the car to avoid being caught with them. After Man does that the police car passes them without pulling them over. The body crab then gets hit by a train while it is still looking for them.\nPedro and Man pull into a theater. They go in and try to find a parking spot. They pull into a spot near theatre speakers and hear knocking from inside their trunk. They then have to park somewhere else so they won't be spotted letting whoever is in the trunk out. Unfortunately, the key breaks off in the lock so Man has to search for a crow bar but he's unsuccessful. Pedro gets out of the car and urinates on the trunk and a camera cut reveals there are two people in the trunk and are afraid of being peed on. The credits start to roll on the movie theater movie and the movie theater speaker announces the movie has ended. Just then Man returns with a load of snacks. Pedro and Man leave the theater.",
+          "context_id": "8a5c13661e3da1859052acad3aa863a22a6a50a2",
+          "qas": [
+            {
+              "question": "Who does Pedro see on the street?",
+              "id": "b85789663202df0a3c554fa9ba22793ffe43a9eb",
+              "answers": [
+                {
+                  "text": "Man",
+                  "answer_start": 318
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the character who chases a car after smelling marijuana?",
+              "id": "5750dae8f371863da7d4fafeeb4db2ff70488a38",
+              "answers": [
+                {
+                  "text": "Buster",
+                  "answer_start": 57
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Are We There Yet? (film)",
+      "url": "https://en.wikipedia.org/wiki/Are_We_There_Yet%3F_(film)",
+      "paragraphs": [
+        {
+          "context": "Children Lindsey and Kevin Kingston sabotage the relationships of their divorced mother, determined to keep her single until their parents reconcile. Nick Persons, a businessman who hates children, purchases a brand-new 2004 Lincoln Navigator and boasts with his beloved bobble-head of Satchel Paige, who comes to life at its own will \u2013 though only Nick can  hear him. When he reaches his shop, he witnesses the woman of his dreams, Suzanne Kingston. On his way to talk to her, he is disgusted to find she has two kids, who turn out to be Lindsey and Kevin.\nLater that night, Nick runs into Suzanne on his way home, asking for a jump start because her car has broken down. After receiving an electric shock, he agrees to take her home, and once there, agrees to transport her wherever she needs to go. On New Year's Eve, he brings her to an airport to go to Vancouver for a business meeting, but her ex-husband calls to say he is sick and cannot bring the children to the airport, leaving her to put her trust in Nick.\nOnce at her house, he meets Kevin and Lindsey for the second time and gives them \"gifts\" (a pizza coupon for Lindsey and a corkscrew for Kevin). They go to the airport to park, where Kevin accidentally damages Nick's car door. Nick yells at Kevin for having his car door damaged, making him cry, but bribes him with 10 dollars to make sure he doesn't get in trouble by the police. Inside the airport, Nick is tackled by security after Kevin learns that corkscrews are illegal to bring on planes so he ditches the item in Nick's jacket pocket. After taking a train instead, the two kids jump off to collect a toy just as Nick boards, forcing him to jump off and land unsafely. When they lose their luggage, they reluctantly drive.",
+          "context_id": "75b65745449a9e458491b0c36743bc328845ad9a",
+          "qas": [
+            {
+              "question": "What is the full name of the person who is bribed with 10 dollars?",
+              "id": "89c52d4cb9e7ce0d86f13f55c70038721a02f84d",
+              "answers": [
+                {
+                  "text": "Kevin Kingston",
+                  "answer_start": 20
+                }
+              ]
+            },
+            {
+              "question": "What divorced mom needs help with her car?",
+              "id": "a2b538528693a14cea3b39596afc5d8cc2de9664",
+              "answers": [
+                {
+                  "text": "Suzanne",
+                  "answer_start": 591
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Margaret Murray",
+      "url": "https://en.wikipedia.org/wiki/Margaret_Murray",
+      "paragraphs": [
+        {
+          "context": "Margaret Murray was born on 13 July 1863 in Calcutta, Bengal Presidency, then a major military city in British India. A member of the wealthy British imperial elite, she lived in the city with her family: parents James and Margaret Murray, an older sister named Mary, and her paternal grandmother and great-grandmother. James Murray, born in India of English descent, was a businessman and manager of the Serampore paper mills who was thrice elected President of the Calcutta Chamber of Commerce. His wife, Margaret (n\u00e9e Carr), had moved to India from Britain in 1857 to work as a missionary, preaching Christianity and educating Indian women. She continued with this work after marrying James and giving birth to her two daughters.\nAlthough most of their lives were spent in the European area of Calcutta, which was walled off from the indigenous sectors of the city, Murray encountered members of indigenous society through her family's employment of 10 Indian servants and through childhood holidays to Mussoorie. The historian Amara Thornton has suggested that Murray's Indian childhood continued to exert an influence over her throughout her life, expressing the view that Murray could be seen as having a hybrid transnational identity that was both British and Indian. During her childhood, Murray never received a formal education, and in later life expressed pride in the fact that she had never had to sit an exam before entering university.In 1870, Margaret and her sister Mary were sent to Britain, there moving in with their uncle John, a vicar, and his wife Harriet at their home in Lambourn, Berkshire. Although John provided them with a strongly Christian education and a belief in the inferiority of women, both of which she would reject, he awakened Murray's interest in archaeology through taking her to see local monuments. In 1873, the girls' mother arrived in Europe and took them with her to Bonn in Germany, where they both became fluent in German. In 1875 they returned to Calcutta, staying there till 1877. They then moved with their parents back to England, where they settled in Sydenham, South London. There, they spent much time visiting The Crystal Palace, while their father worked at his firm's London office. In 1880, they returned to Calcutta, where Margaret remained for the next seven years. She became a nurse at the Calcutta General Hospital, which was run by the Sisters of the Anglican Sisterhood of Clower, and there was involved with the hospital's attempts to deal with a cholera outbreak. In 1887, she returned to England, moving to Rugby, Warwickshire, where her uncle John had moved, now widowed. Here she took up employment as a social worker dealing with local underprivileged people. When her father retired and moved to England, she moved into his house in Bushey Heath, Hertfordshire, living with him until his death in 1891. In 1893 she then travelled to Madras, Tamil Nadu, where her sister had moved to with her new husband.",
+          "context_id": "c8f7ee6c8a06a9e0d789498478727de18e5fe478",
+          "qas": [
+            {
+              "question": "What is the first name of the person who had an interest in archaeology?",
+              "id": "5d98f14bb75380ba1586a2f65b8c923f92282ebd",
+              "answers": [
+                {
+                  "text": "Margaret",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What were the first names of the two daughters that Margaret had after marrying James?",
+              "id": "978d3c887fae3b05c825a84cd2726bf26bcb4f6f",
+              "answers": [
+                {
+                  "text": "Margaret",
+                  "answer_start": 0
+                },
+                {
+                  "text": "Mary",
+                  "answer_start": 262
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who lived in Calcutta with her family?",
+              "id": "da4630cdda35e10de72eedc75d04ff90313726f9",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 869
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person whose father was born in India of English descent?",
+              "id": "2a6093af10b3fa199df4f682b763cb3d2dcccfea",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 869
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person whose father was a businessman?",
+              "id": "1f2d418b1585cba1fe7e6f3000e18ebbc0996e11",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 869
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person whose father was manager of the Serampore paper mills?",
+              "id": "3091bdf28bf2034bc18e3e62552b758b4c395b95",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 869
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person whose father was thrice elected President of the Calcutta Chamber of Commerce?",
+              "id": "5b4df7425edc238e7938689532f1d6db2eba649e",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 869
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person whose mother had moved to India from Britain in 1857?",
+              "id": "c6654d39c09c54aeab690d33db6686bcf77a46da",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 869
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person whose mother worked as a missionary?",
+              "id": "b0355f7d1b2df3a0bf8e2545db48b46d773c5b0c",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 869
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who married James and gave birth to her two daughters?",
+              "id": "ad54ee47627733ef1e38202bc10e8d2066474d6e",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 869
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person whose father was a businessman and manager of the Serampore paper mills?",
+              "id": "796581726377680a9dea7f8ffedcfb3c70d4d9f0",
+              "answers": [
+                {
+                  "text": "Margaret Murray",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person whose mother moved to India from Britain in 1857?",
+              "id": "2387974f0bbeb98f6032debc567cc7b5fa96d49c",
+              "answers": [
+                {
+                  "text": "Margaret Murray",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person whose mother worked as a missionary?",
+              "id": "c3670ba7eced9ad551e4ccec33b0519e0748c951",
+              "answers": [
+                {
+                  "text": "Margaret Murray",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who never had to sit an exam before entering university?",
+              "id": "270c93ef5bab94481f4f392a16831e583f0de68b",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 1178
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who rejected a Christian education?",
+              "id": "eeb3aa4f720f594306eb33d02f8547386aaf0f0c",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 1178
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who rejected the belief that women were inferior to men?",
+              "id": "ec112b1475d0dfa4ae23306eeea1c79dba2ed579",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 1178
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who took his daughter to see local monuments?",
+              "id": "8031bcb5fd01f0084a3b04300d8168cd5ccf93b3",
+              "answers": [
+                {
+                  "text": "James",
+                  "answer_start": 213
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "Encouraged by her mother and sister, Murray decided to enroll at the newly opened department of Egyptology at University College London (UCL) in Bloomsbury, Central London. Having been founded by an endowment from Amelia Blanford Edwards, one of the co-founders of the Egypt Exploration Fund (EEF), the department was run by the pioneering early archaeologist Sir William Flinders Petrie, and based in the Edwards Library of UCL's South Cloisters. Murray began her studies at UCL at age 30 in January 1894, as part of a class composed largely of other women and older men. There, she took courses in the Ancient Egyptian and Coptic languages which were taught by Francis Llewellyn Griffith and Walter Ewing Crum respectively.Murray soon got to know Petrie, becoming his copyist and illustrator and producing the drawings for the published report on his excavations at Qift, Koptos. In turn, he aided and encouraged her to write her first research paper, \"The Descent of Property in the Early Periods of Egyptian History\", which was published in the Proceedings of the Society for Biblical Archaeology in 1895. Becoming Petrie's de facto though unofficial assistant, Murray began to give some of the linguistic lessons in Griffith's absence. In 1898 she was appointed to the position of Junior Lecturer, responsible for teaching the linguistic courses at the Egyptology department; this made her the first female lecturer in archaeology in the United Kingdom. In this capacity, she spent two days a week at UCL, devoting the other days to caring for her ailing mother. As time went on, she came to teach courses on Ancient Egyptian history, religion, and language. Among Murray's students \u2013 to whom she referred as \"the Gang\" \u2013 were several who went on to produce noted contributions to Egyptology, including Reginald Engelbach, Georgina Aitken, Guy Brunton, and Myrtle Broome. She supplemented her UCL salary by teaching evening classes in Egyptology at the British Museum.",
+          "context_id": "29253a0a974d8e762d87759a2101fda6ffe3eb9e",
+          "qas": [
+            {
+              "question": "What is the name of the person who took courses in the Ancient Egyptian and Coptic languages at UCL?",
+              "id": "b978ce3e4c1c5f335684b362b7c138e30085970f",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 448
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person who aided and encouraged Murray to write her first research paper?",
+              "id": "ebdcc46458cbf6a7e47c7bf6daec7b5a23870ecf",
+              "answers": [
+                {
+                  "text": "William Flinders Petrie",
+                  "answer_start": 364
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who was appointed to the position of Junior Lecturer in 1898?",
+              "id": "90858252cf30fc2fd8d40363aedb429381240fd1",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 1166
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person whose appointment to Junior Lecturer made her the fist female lecturer in archeology in the United Kingdom?",
+              "id": "80287fbc9b5478ba6fb9fe90cc1d40db0068cf6c",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 1166
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who spent two days a week at UCL in the capacity of Junior Lecturer?",
+              "id": "3b386cd48dcdda036197b1baab534fdcaf8c25cc",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 1166
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who came to teach courses on Ancient Egyptian history, religion, and language?",
+              "id": "f60e2cb225eeafbe64304e0d4efb6038357614bf",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 1166
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who supplemented her UCL salary by teaching evening classes in Egyptology at the British Museum?",
+              "id": "35d946e29bf6a1cfad461f8b6d79020b421e2d2c",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 1670
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "At this point, Murray had no experience in field archaeology, and so during the 1902\u201303 field season, she travelled to Egypt to join Petrie's excavations at Abydos. Petrie and his wife, Hilda Petrie, had been excavating at the site since 1899, having taken over the archaeological investigation from French Coptic scholar \u00c9mile Am\u00e9lineau. Murray at first joined as site nurse, but was subsequently taught how to excavate by Petrie and given a senior position. This led to some issues with some of the male excavators, who disliked the idea of taking orders from a woman. This experience, coupled with discussions with other female excavators (some of whom were active in the feminist movement) led Murray to adopt openly feminist viewpoints. While excavating at Abydos, Murray uncovered the Osireion, a temple devoted to the god Osiris which had been constructed by order of Pharaoh Seti I during the period of the New Kingdom. She published her site report as The Osireion at Abydos in 1904; in the report, she examined the inscriptions that had been discovered at the site to discern the purpose and use of the building.During the 1903\u201304 field season, Murray returned to Egypt, and at Petrie's instruction began her investigations at the Saqqara cemetery near to Cairo, which dated from the period of the Old Kingdom. Murray did not have legal permission to excavate the site, and instead spent her time transcribing the inscriptions from ten of the tombs that had been excavated during the 1860s by Auguste Mariette. She published her findings in 1905 as Saqqara Mastabas I, although would not publish translations of the inscriptions until 1937 as Saqqara Mastabas II. Both The Osireion at Abydos and Saqqara Mastabas I proved to be very influential in the Egyptological community, with Petrie recognising Murray's contribution to his own career.",
+          "context_id": "05e4139cb89e425cda6d06fd823ec8ab7a8ceb70",
+          "qas": [
+            {
+              "question": "What is the last name of the woman some male excavators disliked the idea of taking orders from?",
+              "id": "654e8c3a52fcf7f78e98e3bafde19e71669e0eb0",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 339
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who examined the inscriptions that had been discovered at the site?",
+              "id": "ef0485b61f3720c7ab725b6fe3e513bc8a95b253",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 339
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who began her investigations at the Saqqara cemetery near to Cairo?",
+              "id": "aef92ac4df56e501d238ce9ca1fdd83a20b3369c",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 339
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who spent her time transcribing the inscriptions from ten of the tombs?",
+              "id": "dae6dfcf06ecfdfed744b37103bf4683e3e30d37",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 339
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who published her findings in 1905 as Saqqara Mastabas I?",
+              "id": "d755dd2036b95a8d331fcea7557236d8a1cc26c7",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 15
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who travelled to Egypt to join Petrie's excavations at Abydos?",
+              "id": "038a2588718c30edfbef442efc16411b751754f2",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 15
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "Murray's interest in folklore led her to develop an interest in the witch trials of Early Modern Europe. In 1917, she published a paper in Folklore, the journal of the Folklore Society, in which she first articulated her version of the witch-cult theory, arguing that the witches persecuted in European history were actually followers of \"a definite religion with beliefs, ritual, and organization as highly developed as that of any cult in the end\". She followed this up with papers on the subject in the journals Man and the Scottish Historical Review. She articulated these views more fully in her 1921 book The Witch-Cult in Western Europe, published by Oxford University Press after receiving a positive peer review by Henry Balfour, and which received both criticism and support on publication. Many reviews in academic journals were critical, with historians claiming that she had distorted and misinterpreted the contemporary records that she was using, but the book was nevertheless influential.\nOn the basis of her work in Malta, Louis C. G. Clarke, the curator of the Cambridge Museum of Ethnology and Anthropology, invited her to lead excavations on the island of Menorca from 1930 to 1931. With the aid of Guest, she excavated the talaiotic sites of Trepuc\u00f3 and Sa Torreta de Tramuntana, resulting in the publication of Cambridge Excavations in Minorca. Murray also continued to publish works on Egyptology for a general audience, such as Egyptian Sculpture (1930) and Egyptian Temples (1931), which received largely positive reviews. In the summer of 1925 she led a team of volunteers to excavate Homestead Moat in Whomerle Wood near to Stevenage, Hertfordshire; she did not publish an excavation report and did not mention the event in her autobiography, with her motives for carrying out the excavation remaining unclear.In 1924, UCL promoted Murray to the position of assistant professor, and in 1927 she was awarded an honorary doctorate for her career in Egyptology. That year, Murray was tasked with guiding Mary of Teck, the Queen consort, around the Egyptology department during the latter's visit to UCL. The pressures of teaching had eased by this point, allowing Murray to spend more time travelling internationally; in 1920 she returned to Egypt and in 1929 visited South Africa, where she attended the meeting of the British Association for the Advancement of Science, whose theme was the prehistory of southern Africa. In the early 1930s she travelled to the Soviet Union, where she visited museums in Leningrad, Moscow, Kharkiv, and Kiev, and then in late 1935 she undertook a lecture tour of Norway, Sweden, Finland, and Estonia.",
+          "context_id": "7ced3265426be6106dda189e2c1e26ea9a766337",
+          "qas": [
+            {
+              "question": "What is the name of the person whose work in Malta was the basis for the curator of the Cambridge Museum of Ethnology and Anthropology to invite her to lead excavations on Menorca?",
+              "id": "0388381391a3a4337a5cbdde7f94c02780187c12",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who was included to lead excavations on the island of Menorca from 1930 t o1931?",
+              "id": "dfcb840b87787f56b0531e07acc9d135fe2252f1",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who excavated the talaiotic sites of Trepuc\u00f3 and Sa Torreta de Tramuntana?",
+              "id": "4fc73652ac8723944ef0b7bf0220fd7fdb0aa555",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who historians claimed had distorted and misinterpreted the contemporary records being used?",
+              "id": "9e5b92fb41de2097006113c0de2c173e3a195768",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person whose 1921 book, The Witch-Cult in Western Europe, received a positive peer review from Balfour?",
+              "id": "733032fa21ac66f100ad5feeab5fb16f5ae61492",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "Upon initial publication, Murray's thesis gained a favourable reception from many readers, including some significant scholars, albeit none who were experts in the witch trials. Historians of Early Modern Britain like George Norman Clark and Christopher Hill incorporated her theories into their work, although the latter subsequently distanced himself from the theory. For the 1961 reprint of The Witch-Cult in Western Europe, the Medieval historian Steven Runciman provided a foreword in which he accepted that some of Murray's \"minor details may be open to criticism\", but in which he was otherwise supportive of her thesis. Her theories were recapitulated by Arno Runeberg in his 1947 book Witches, Demons and Fertility Magic as well as Pennethorne Hughes in his 1952 book Witches. As a result, the Canadian historian Elliot Rose, writing in 1962, claimed that the Murrayite interpretations of the witch trials \"seem to hold, at the time of writing, an almost undisputed sway at the higher intellectual levels\", being widely accepted among \"educated people\".Rose suggested that the reason that Murray's theory gained such support was partly because of her \"imposing credentials\" as a member of staff at UCL, a position that lent her theory greater legitimacy in the eyes of many readers. He further suggested that the Murrayite view was attractive to many as it confirmed \"the general picture of pre-Christian Europe a reader of Frazer or [Robert] Graves would be familiar with\". Similarly, Hutton suggested that the cause of the Murrayite theory's popularity was because it \"appealed to so many of the emotional impulses of the age\", including \"the notion of the English countryside as a timeless place full of ancient secrets\", the literary popularity of Pan, the widespread belief that the majority of British had remained pagan long after the process of Christianisation, and the idea that folk customs represented pagan survivals. At the same time, Hutton suggested, it seemed more plausible to many than the previously dominant rationalist idea that the witch trials were the result of mass delusion. Related to this, the folklorist Jacqueline Simpson suggested that part of the Murrayite theory's appeal was that it appeared to give a \"sensible, demystifying, liberating approach to a longstanding but sterile argument\" between the rationalists who denied that there had been any witches and those, like Montague Summers, who insisted that there had been a real Satanic conspiracy against Christendom in the Early Modern period replete with witches with supernatural powers. \"How refreshing\", noted the historian Hilda Ellis Davidson, \"and exciting her first book was at that period. A new approach, and such a surprising one.\"",
+          "context_id": "4b7f99148e7c19075b58506e3658ed66c7ad94f0",
+          "qas": [
+            {
+              "question": "Whose theories were incorporated into Clark and Hill's work?",
+              "id": "a9258cee1bab212ee3a3a03bdbad49c68c7e955d",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 26
+                }
+              ]
+            },
+            {
+              "question": "Whose theory did Hill distance himself from?",
+              "id": "b1c0e66520ff31cf2a25668cf7548378c2fa6482",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 26
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person who wrote The Witch-Cult in Western Europe?",
+              "id": "4915f39a02e9e6bf26fb91a210dfb5ff05265b6b",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 521
+                }
+              ]
+            },
+            {
+              "question": "Whose theories were recapitulated by Arno Runeberg?",
+              "id": "395a334efe2611e1d9834e4b66cc49297c50b249",
+              "answers": [
+                {
+                  "text": "Murray",
+                  "answer_start": 26
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person that suggested that the cause of the Murrayite theory's popularity was because it \"appealed to so many of the emotional impulses of the age?\"",
+              "id": "6ab2a474f63e4ac1cfbead248644465723b27138",
+              "answers": [
+                {
+                  "text": "Hutton",
+                  "answer_start": 1495
+                }
+              ]
+            },
+            {
+              "question": "What was said to \"appealed to so many of the emotional impulses of the age?\"",
+              "id": "2bb8a12700dffc5d36f076052bd4b7f285f3877b",
+              "answers": [
+                {
+                  "text": "the Murrayite theory",
+                  "answer_start": 1530
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Resident Evil: Vendetta",
+      "url": "https://en.wikipedia.org/wiki/Resident_Evil:_Vendetta",
+      "paragraphs": [
+        {
+          "context": "The story is set in between the events of Resident Evil 6 and Resident Evil 7: Biohazard. BSAA agent Chris Redfield is tracking Glenn Arias, a Brazilian-American death merchant and a former CIA operative who is wanted by both the Interpol and FBI. Arias is on a mission of vengeance against the U.S. government for killing his friends and family in a drone strike at their wedding. Chris and his fellow agents infiltrate a mansion in Mexico, to rescue their missing undercover source, Cathy White. Inside the mansion, Chris's fellow agents are ambushed by zombies and death traps, with Chris being the sole survivor and barely making it out alive. Chris then comes face-to-face with Arias outside the mansion and is defeated by him in close quarters combat . He then finds out that Cathy has become a zombie under Arias's control. As Arias leaves with his associates, Maria and Diego Gomez, the BSAA rescues Chris by slaughtering Cathy and the remaining zombie horde. Meanwhile, Professor Rebecca Chambers, former S.T.A.R.S. unit member and survivor of the Mansion incident, studies a new virus coined the \"Animality Virus\"\u2014\"A-Virus\" for short\u2014that is capable of laying dormant inside any individual until the right trigger is presented. She identifies three components to the virus: the base virus, the trigger virus, and the vaccine. The research labs are soon attacked by Maria, and releases the virus via aerosol form. While her colleagues quickly turn into zombies, Rebecca is able to formulate a vaccine to make herself immune. After fending off some zombies, Rebecca is then rescued by Chris, who briefs her on his mission.",
+          "context_id": "f2e52a128b926836574453431f4705565a77e484",
+          "qas": [
+            {
+              "question": "What does the woman that the BSAA agent is trying to rescue become?",
+              "id": "51eb2c388ee9553846b74b0bb1ad3a562c1a56bd",
+              "answers": [
+                {
+                  "text": "a zombie",
+                  "answer_start": 799
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Ayumi Hamasaki",
+      "url": "https://en.wikipedia.org/wiki/Ayumi_Hamasaki",
+      "paragraphs": [
+        {
+          "context": "Ayumi Hamasaki (\u6d5c\u5d0e\u3042\u3086\u307f, Hamasaki Ayumi, born October 2, 1978) is a Japanese singer, songwriter, record producer, actress, model, spokesperson and entrepreneur. Through her entire career, she has written almost all her lyrical content, and has sometimes composed her music.\nBorn and raised in Fukuoka, Fukuoka Prefecture, Hamasaki moved to Tokyo at fourteen in 1993 to pursue a career in singing and acting. In 1998, under the tutelage of Avex CEO Max Matsuura, Hamasaki released her debut single \"Poker Face\" and debut major-label album A Song for XX. The album debuted at the top of the Oricon charts and remained there for five weeks, selling over a million copies. Her next ten albums shipped over a million copies in Japan, with her third, Duty, selling nearly three million. A Best, her first compilation album, is her best-selling album, with more than four million copies sold in Japan. Since 2006, after her album Secret was released, album and single sales have declined.Hamasaki has sold over 50 million records, making her the best-selling Japanese solo artist of all time. Hamasaki has several domestic record achievements for her singles, such as the most number-one hits by a female artist (38); the most consecutive number-one hits by a solo artist (twenty-five), and the most million-sellers. From 1999 to 2010, Hamasaki had at least two singles each year topping the charts. Hamasaki is the first female recording artist to have ten studio albums since her debut to top the Oricon and the first artist to have a number-one album for 13 consecutive years since her debut. Hamasaki's second remix album, Super Eurobeat Presents Ayu-ro Mix, is recognized as one of the best selling remix albums of all time and remains her only album to be recognized in a worldwide accreditation.During the height of her career, Hamasaki has been dubbed as the \"Empress of J-pop\" because of her popularity in Japan and Asia. Following an ear infection in 2000, she has suffered worsening hearing loss and is completely deaf in one ear.",
+          "context_id": "3a9037edf3fd500f405638bd26a5a8e995f57b5e",
+          "qas": [
+            {
+              "question": "What was the name of the album that debuted at the top of the Oricon charts and remained there for five weeks?",
+              "id": "692cd34c4d661666bda8bbce156d110f0bff02db",
+              "answers": [
+                {
+                  "text": "A Song for XX",
+                  "answer_start": 535
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person whose debut single \"Poker Face\" was released in 1998?",
+              "id": "a9c92726a255e36793d4cc7530364eb4a51f989a",
+              "answers": [
+                {
+                  "text": "Ayumi Hamasaki",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Snowbound (1948 film)",
+      "url": "https://en.wikipedia.org/wiki/Snowbound_(1948_film)",
+      "paragraphs": [
+        {
+          "context": "British film director Derek Engles recognises Neil Blair, a former extras in one of his earlier productions. In order to investigate some intelligence which he had picked up in Italy, Engles offers Blair a new job because he trusts him (he used to be Blair's commanding officer). He wants Blair to keep him posted on the activities of everyone who stays at a ski hut, whilst he poses as a scriptwriter. Blair accepts this offer. Engles warns him to look out for a Carla Rometta and sends along a cameraman, Joe Wesson, to accompany him.\nAt the inn, Aldo, the indifferent innkeeper, tells themthat there are no rooms available, however guest Stefano Valdini helps them to find a room. Englishman Gilbert Mayne also takes a room. Blair soon encounters Rometta, who calls herself the Comtessa Forelli. That night, a Greek named Keramikos also arrives.\nWhen Blair makes his first report, Engles is particularly interested in the fact that the hut is to be auctioned off the next day. The proprietor of the hotel below confides to Blair that the auction is rigged and that there will only be one bid, his, but instead there is a heated bidding war involving Valdini (on the Comtessa's behalf) and a lawyer for an unknown party. The latter wins the auction by making an excessive bid.\nKeramikos tells Blair that he is not truly there to write a script. He also claims that Mayne was a deserter from the British Army who ended up working for him in Greece, though he declines to divulge any more. Blair begins falling in love with the comtessa, who admits she is Carla. Very late at night, by chance, Blair spots Keramikos speaking German with another man. However, when Blair confronts Keramikos, the Greek tells him to mind his own business.",
+          "context_id": "c4a6def4b8e78b9574eeb46df012b721f0714d73",
+          "qas": [
+            {
+              "question": "What is the last name of the person that picked up intelligence in Italy?",
+              "id": "3c1b9a8b523b5bed422c6e701b8ff790f2a9ac78",
+              "answers": [
+                {
+                  "text": "Engles",
+                  "answer_start": 28
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person that is warned to look out for Rometta?",
+              "id": "bb9a59a89ac36e0dd18f9740314bac115bf51112",
+              "answers": [
+                {
+                  "text": "Blair",
+                  "answer_start": 403
+                }
+              ]
+            },
+            {
+              "question": "Who wins the auction for the hut?",
+              "id": "a724932f7cc45006fe672e7e1c7e9a112088e275",
+              "answers": [
+                {
+                  "text": "a lawyer for an unknown party",
+                  "answer_start": 1191
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "American Movie",
+      "url": "https://en.wikipedia.org/wiki/American_Movie",
+      "paragraphs": [
+        {
+          "context": "In 1996, Mark Borchardt, a blue-collar suburbanite, dreams of being a filmmaker. However, he is also an unemployed, deeply indebted, borderline alcoholic who still lives with his parents and is estranged from his ex-girlfriend, who is threatening to revoke custody of their three children. He acknowledges his various failures but aspires to one day make more of his life.\nIn an attempt to jump-start his amateur film making career, Mark restarts production on Northwestern, a feature-length film Mark has been planning for most of his adult life. Initially, the project attracts some interest from the group of amateur actors with whom Mark produces radio plays, but by the fourth production meeting, almost no one shows up and Mark is forced to acknowledge that he currently lacks the resources to ever move Northwestern past the pre-production phase.\nIn an attempt to drum up the attention and financial resources needed to film Northwestern, Mark decides to finally complete Coven (which Borchardt mispronounces with a long 'o'), a horror short that he began shooting on 16mm film in 1994 but ultimately abandoned. Mark receives financing from his uncle Bill, a wise but increasingly senile eighty-two-year-old retiree who lives in a dilapidated trailer despite having nearly $300,000 in his bank account. Bill hesitantly agrees to invest in Coven with the goal of selling three thousand VHS tapes, which he hopes will raise enough capital to finance Northwestern.",
+          "context_id": "48cd9eb4a1b900e71f6ff73f7d3cca0eb0c2a285",
+          "qas": [
+            {
+              "question": "What is the first name of the person that the senile old man agrees to finance?",
+              "id": "12417acbf52e50b6cb2510226185a4fcd3d404db",
+              "answers": [
+                {
+                  "text": "Mark",
+                  "answer_start": 1119
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Bye Bye Birdie (film)",
+      "url": "https://en.wikipedia.org/wiki/Bye_Bye_Birdie_(film)",
+      "paragraphs": [
+        {
+          "context": "Conrad Birdie, a popular rock and roll star, receives an Army draft notice, devastating his teenage fans across the nation. Albert Peterson is an unsuccessful songwriter, and music is the family business, although he has a doctorate in biochemistry. He schemes with his secretary and long-suffering girlfriend Rosie DeLeon to have Conrad sing a song Albert will write. Rosie convinces Ed Sullivan to have Conrad perform Albert's song \"One Last Kiss\" on The Ed Sullivan Show, and then kiss a randomly chosen high school girl goodbye before going off to the Army. Once he achieves this success, Albert will feel free to marry Rosie, despite his widowed, meddlesome mother Mae's (Maureen Stapleton) long history of ensuring nothing will come between her and her beloved son.\nSweet Apple, Ohio, is chosen as the location for Conrad's farewell performance. The random lucky girl chosen is Kim MacAfee, who is thrilled. Kim already has a high school sweetheart, Hugo Peabody, who is not so thrilled. The teenagers of Sweet Apple, blissfully unaware of their town's impending fame, are spending the \"Telephone Hour\" catching up on the latest gossip: Kim and Hugo have just gotten pinned (indicating a serious commitment to each other) and Kim feels grown up.\nShe sings \"How Lovely to be a Woman\". On the day Conrad arrives in town, the teenaged girls sing their anthem to him, \"We Love You Conrad\", but the boys despise him for their girls' love for him (\"We Hate You Conrad!\"). Sweet Apple becomes a very popular place, but some of the local adults are unhappy with the sudden celebrity, especially after Conrad's \"Honestly Sincere\" song coupled with his hip-thrusting moves causes every female, beginning with the mayor's wife, to faint.",
+          "context_id": "909280f16987ab5cbafacd72a81ec27f481d16b7",
+          "qas": [
+            {
+              "question": "What is the first name of the person who sings \"How Lovely to be a Woman?\"",
+              "id": "fbc863f585341dc648a5d0531953d1448d343830",
+              "answers": [
+                {
+                  "text": "Kim",
+                  "answer_start": 1143
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who will be free to marry once they achieve success?",
+              "id": "d582d13387f6717e487e2339eea3077b5103ec07",
+              "answers": [
+                {
+                  "text": "Albert",
+                  "answer_start": 593
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person whose mother is widowed?",
+              "id": "c8f140a308d7779c919e6c542dffb8946c81cbe4",
+              "answers": [
+                {
+                  "text": "Albert",
+                  "answer_start": 593
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "House on Haunted Hill (1999 film)",
+      "url": "https://en.wikipedia.org/wiki/House_on_Haunted_Hill_(1999_film)",
+      "paragraphs": [
+        {
+          "context": "In 1931, the patients at the Vannacutt Psychiatric Institute for the Criminally Insane revolt against the staff headed by the sadistic Dr. Richard B. Vannacutt. The patients start a fire which engulfs the building, killing all of the inmates and all but five of Vannacutt's staff.\nIn 1999, Evelyn Stockard-Price is in a disintegrating marriage with Steven Price, an amusement park mogul. At Evelyn's insistence, Price stages her birthday party at the long-abandoned hospital. The building's owner, Watson Pritchett, is convinced it is evil, having lived there as a child when it was converted to a private residence. Five guests arrive for the party: film producer Jennifer Jenzen; baseball player Eddie Baker; former television personality Melissa Marr; Donald Blackburn, a physician; and Pritchett. The guests are not the ones Price invited and neither of the Prices know who they are. Despite this, Price continues the party's advertised theme, offering $1 million to each guest who remains in the house until morning; those who flee forfeit their $1 million to the others.\nThe building's security system is mysteriously tripped, locking everyone inside \u2013 a stunt which Price blames on Evelyn. Jennifer, Eddie and Pritchett search the basement for the control panel. While exploring the labyrinthine basement, Jennifer confesses to Eddie that her real name is Sara Wolfe, the recently fired assistant to the real Jennifer. She impersonated Jennifer hoping to win the prize money. Shortly after, Sara is nearly drowned in a tank of blood by a ghost impersonating Eddie, but the real Eddie arrives in time to save her. Melissa subsequently disappears, leaving behind a massive trail of blood. Price visits his assistant Schechter, who is supposed to be managing the party stunts, but finds him horribly mutilated. On the surveillance monitor he sees the ghost of Dr. Vannacutt walking around with a bloody saw.",
+          "context_id": "d186c46e716532ebf40b68ef073bf80ee0236147",
+          "qas": [
+            {
+              "question": "What is the real full name of the person that searches the basement with Eddie and Pritchett?",
+              "id": "bab72e9869c9cabe9a297d173ff8bef50b10c13e",
+              "answers": [
+                {
+                  "text": "Sara Wolfe",
+                  "answer_start": 1363
+                }
+              ]
+            },
+            {
+              "question": "Where does the baseball player look for the control panel?",
+              "id": "1a4888d092312d1f0acf6517c73f6fd589df5600",
+              "answers": [
+                {
+                  "text": "the basement",
+                  "answer_start": 1234
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person that sees the ghost of Dr. Vannacut on a monitor?",
+              "id": "459517338918bbd2d8f0c699844695b70ee22dac",
+              "answers": [
+                {
+                  "text": "Steven Price",
+                  "answer_start": 349
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Lovers (2017 film)",
+      "url": "https://en.wikipedia.org/wiki/The_Lovers_(2017_film)",
+      "paragraphs": [
+        {
+          "context": "Mary and Michael are a married couple. They live together, but are estranged from one another. They are both having long-standing extramarital affairs\u2014she with Robert and he with Lucy. Their lovers have both emphatically demanded they break up the marriage and Mary and Michael have vowed that they will do so after a visit from their son, Joel, and his new girlfriend, Erin.\nThis plan goes awry, however, when an early-morning kiss between Mary and Michael leads to sex. They find themselves falling in love again and having passionate sexual encounters. Simultaneously, their respective lovers become more and more needy and demanding, which makes them less appealing to Mary and Michael.\nOn the train to see his parents, Joel warns Erin that their marriage is a failed one and that his parents are horrible people. He is immediately tense and wary when he enters their house, but is surprised to find his parents acting lovingly toward one another. He begins to think they may have changed.\nMary's and Michael's lovers become increasingly agitated. Robert is the first to confront his rival, telling Michael in a grocery store that Mary is going to leave him. Then, Lucy approaches Mary in her car and hisses at her. These confrontations cause the renewed rapport between Mary and Michael and their son to fall apart. Mary leaves the house for several hours and cries in her car. Joel's anger boils over and he punches a hole in a wall.\nWhen Mary returns to the house, Joel storms out, after crying in Erin's arms. Mary and Michael do not appear to be upset with each other, but the next scene shows them packing their belongings to depart the house. Following scenes show Mary at Robert's house and Michael at Lucy's.\nHowever, the film ends with Michael phoning Mary and telling her, \"I can't stop thinking about you.\"",
+          "context_id": "8f16daed0e8bf96a337dd0624899c701531e353e",
+          "qas": [
+            {
+              "question": "Who is the wife of Michael having an affair with?",
+              "id": "b9291f09fc000c386ee1ed63622f070fc0be34a2",
+              "answers": [
+                {
+                  "text": "Robert",
+                  "answer_start": 160
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Tallulah (film)",
+      "url": "https://en.wikipedia.org/wiki/Tallulah_(film)",
+      "paragraphs": [
+        {
+          "context": "Living in her rundown van while travelling around America, homeless teenager Tallulah and her boyfriend Nico survive the streets by stealing credit cards. \nWhen Nico decides it is time to go home to his mother, Tallulah expresses her dismay and argues with Nico about how she will not change her lifestyle. Tallulah is devastated to discover the next morning that Nico has left without saying goodbye. \nDesperate to be with him again, Tallulah drives to New York City, where Nico's mother Margo lives, and finds her at her apartment. After informing Tallulah that she has not seen Nico in two years, Margo tells Lu to leave.\nWith nowhere else to go, Tallulah steals from guests at a nearby hotel, only for an eccentric and intoxicated mother, Carolyn, to mistake Tallulah as housekeeping staff. To Lu's confusion, Carolyn lets her child wander around naked and play with dangerous objects and admits that she is not invested in being a mother. Carolyn leaves her toddler, Maddy, in Tallulah's care, while she goes on a date with a man who is not her husband. Tallulah bonds with the young Maddy, bathing her and playing games before a devastated Carolyn arrives back at the hotel, distraught that the man did not want her. \nAfter Carolyn drunkenly passes out, Tallulah prepares to leave but impulsively decides to take a crying Maddy back to her van to spend the night until further notice. When Tallulah returns to the hotel with Maddy, she flees upon seeing the police, summoned by a panicked Carolyn, and goes to Margo's apartment. After Tallulah claims that the child is Nico's and that she is Margo's granddaughter, \"Maggie,\" Margo reluctantly agrees to let them stay for one night.",
+          "context_id": "03f14e713508575b4fb197537e9325e2d58b2265",
+          "qas": [
+            {
+              "question": "Who did Tallulah take to her van to spend the night?",
+              "id": "36812d2a3e5677ebdd94ecab842a893b7d6dac51",
+              "answers": [
+                {
+                  "text": "Maddy",
+                  "answer_start": 1328
+                }
+              ]
+            },
+            {
+              "question": "Where does Tallulah's boyfriend say he's going?",
+              "id": "03a4ccf3e95b7e2aaeaf55e9d6a998a89d6e2250",
+              "answers": [
+                {
+                  "text": "home to his mother",
+                  "answer_start": 191
+                }
+              ]
+            },
+            {
+              "question": "What name does Tallulah give Carolyn's daughter?",
+              "id": "1019aeb6d82c8d00ee5c34dfec7c50a54f19218f",
+              "answers": [
+                {
+                  "text": "Maggie",
+                  "answer_start": 1622
+                }
+              ]
+            },
+            {
+              "question": "What does Tallulah tell Margo her granddaughter's name is?",
+              "id": "39ecabe8e6e908e3b9f8dd791fdbd9a43df6e7af",
+              "answers": [
+                {
+                  "text": "Maggie",
+                  "answer_start": 1622
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Crush (2001 film)",
+      "url": "https://en.wikipedia.org/wiki/Crush_(2001_film)",
+      "paragraphs": [
+        {
+          "context": "Forty-something schoolmistress Kate and her two best friends, police superintendent Janine and doctor Molly, live in rural Britain and share their single lives and dating exploits in weekly chats.  Kate has recovered from ovarian cyst disease and fears a relapse; she hasn't been dating much.  By chance, she meets Jed, a former student of hers, now a handsome twenty-something church organist.  To her surprise, she ends up sleeping with him and the two embark on an unlikely relationship that's looked on with suspicion by Janine and Molly.  Janine comes to believe in Kate and Jed's feelings for each other.  But Molly is still dubious, showing Jed's criminal record and medical history to Kate, bringing adult dates to their dinner parties and taking her and Janine to Paris so that she will go off Jed.  Conversely, this brings Kate and Jed closer together and they plan their wedding.\nMolly eventually attempts to prove Jed's faithlessness by seducing him, which fails but angers Kate to the extreme.  After an argument about how Kate has kept their engagement quiet, Jed is thrown out of Kate's house.  He is struck and killed by a passing truck; this unexpected tragedy breaks the three women up, as Kate is inconsolable and Janine blames Molly.  Kate reluctantly embarks on a mild romance with a local vicar who's always been in love with her, but when she finally agrees to marry him, she becomes ill at the altar.  Molly and Janine take her away, and discover that she is pregnant with Jed's child.  She decides to have the baby and raise it on her own, while the vicar meets a woman who's actually excited about him.  Also, Janine starts going out with Bill (a robbery suspect) and Molly falls for a pediatrician named Eleanor.  The three friends reconcile and continue to share their lives and experiences.",
+          "context_id": "776b827c77332d3e36f19bfc5de69032410eb1de",
+          "qas": [
+            {
+              "question": "Who becomes ill at the altar?",
+              "id": "cd810af29a6e1759c7ae1f2865c2816e6545b73c",
+              "answers": [
+                {
+                  "text": "Kate",
+                  "answer_start": 1255
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Gyeongju",
+      "url": "https://en.wikipedia.org/wiki/Gyeongju",
+      "paragraphs": [
+        {
+          "context": "The early history of Gyeongju is closely tied to that of the Silla kingdom, of which it was the capital. Gyeongju first enters non-Korean records as Saro-guk, during the Samhan period in the early Common Era. Korean records, probably based on the dynastic chronicles of Silla, record that Saro-guk was established in 57 BCE, when six small villages in the Gyeongju area united under Bak Hyeokgeose. As the kingdom expanded, it changed its name to Silla. During the Silla period, the city was called \"Seorabeol\" (lit. Capital), \"Gyerim\" (lit. Rooster's forest) or \"Geumseong\" (lit. City of Gold).After the unification of the peninsula up to Taedong River in 668 AD, Gyeongju became the center of Korean political and cultural life. The city was home to the Silla court and the great majority of the kingdom's elite. Its prosperity became legendary, and was reported as far away as Persia according to the 9th century book The Book of Roads and Kingdoms. Records of Samguk Yusa give the city's population in its peak period as 178,936 households, suggesting that the total population was almost one million. Many of Gyeongju's most famous sites date from this Unified Silla period, which ended in the late 9th century by Goryeo (918\u20131392).In 940, the founder of Goryeo, King Taejo, changed the city's name to \"Gyeongju\", which literally means \"Congratulatory district\". In 987, as Goryeo introduced a system in which three additional capitals were established in politically important provinces outside Gaegyeong (nowadays Kaesong), and Gyeongju was designated as \"Donggyeong\" (\"East Capital\"). However, that title was removed in 1012, the third year of King Hyeongjong's reign, due to political rivalries at that time, though Gyeongju was later made the seat of Yeongnam Province. It had jurisdiction over a wide area, including much of central eastern Yeongnam, although this area was greatly reduced in the 13th century. Under the subsequent Joseon (1392\u20131910) dynasties, Gyeongju was no longer of national importance, but remained a regional center of influence. In 1601, the city ceased to be the provincial capital.",
+          "context_id": "acc18c4b30cb6929cb0b11b41fd604ee4ed47296",
+          "qas": [
+            {
+              "question": "When did Gyeongju cease to be the provincial capital?",
+              "id": "8bca2771faa465b70fc1d18c7686a95e2c821017",
+              "answers": [
+                {
+                  "text": "In 1601",
+                  "answer_start": 2064
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "The cuisine of Gyeongju is generally typical of the cuisine elsewhere in Gyeongsang province: spicy and salty. However, it has distinctive tastes according to region and several local specialties known nationwide. The most famous of these is \"Gyeongju bread\" or \"Hwangnam bread\", a red-bean pastry first baked in 1939 and now sold throughout the country. Chalboribbang, made with locally produced glutinous barley, is also a pastry with a filling of red bean paste. Local specialties with a somewhat longer pedigree include beopju, a traditional Korean liquor produced by the Gyeongju Choe in Gyo-dong. The brewing skill and distill master were designated as Important Intangible Cultural Properties by South Korea government.\nOther local specialities include ssambap, haejangguk, and muk. Ssambap refers to a rice dish served with vegetable leaves, various banchan (small side dishes) and condiments such as gochujang (chili pepper paste) or ssamjang (a mixture of soybean paste and gochujang) to wrap them together. Most ssambap restaurants in Gyeongju are gathered in the area of Daenuengwon or Grand Tumuli Park. Haejangguk is a kind of soup eaten as a hangover cure, and means \"soup to chase a hangover\". A street dedicated to haejangguk is located near Gyeongju National Museum, where 20 haejangguk restaurants are gathered to serve the Gyeongju-style haejangguk. The soup is made by boiling soybean sprout, sliced memilmuk (buckwheat starch jelly), sour kimchi (pickled vegetables) and gulfweed in a clear broth of dried anchovy and Alaska pollack.The east district of Gyeongju, Gampo-eup town, is adjacent to the sea, so fresh seafood and jeotgal (fermented salted seafood) are abundant. There are over 240 seafood restaurants in Gampo Harbor offering various dishes made with seafood caught in the sea, such as hoe (raw fish dishes), jeonboktang (an abalone soup), grilled seafood and others.",
+          "context_id": "3ba36a88245d8afb85a3f895c6fdbebf2aac5a0a",
+          "qas": [
+            {
+              "question": "What country is Gyeongju bread sold in?",
+              "id": "ea52803ec38402000d4d368e374740be7898baf8",
+              "answers": [
+                {
+                  "text": "South Korea",
+                  "answer_start": 703
+                }
+              ]
+            },
+            {
+              "question": "What kind of soup is made by boiling soybean sprout, sliced memilmuk, sour kimchi and gulfweed in a clear broth of dried anchovy and Alaska pollack?",
+              "id": "4c745a9704da3bfa284bf285fdd13d3bb64b01ce",
+              "answers": [
+                {
+                  "text": "Haejangguk",
+                  "answer_start": 1117
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Defying Gravity (1997 film)",
+      "url": "https://en.wikipedia.org/wiki/Defying_Gravity_(1997_film)",
+      "paragraphs": [
+        {
+          "context": "John \"Griff\" Griffith, an average college student, is active in his fraternity and lives in the frat house. He has a bunk bed in the room he shares with his best friend Todd Bently, Doogie and his pledge Stewy. Another of his fraternity brothers, Pete Bradley, has moved out of the frat house and into a house he shares with other students. Griff and Pete have a secret sexual relationship, but Griff's close-knit fraternity life puts a strain on it. Griff is satisfied with the arrangement, but Pete is not. Griff, Doogie, Todd, and Heather are studying at the library.  Pete is also there browsing the stacks and overhears Griff inviting girl flirt Gretchen to a fraternity party.  Pete storms out of the library with Griff quickly following. Griff tackles Pete and straddles him and asks, \"What's your problem?\" and \"Come on Pete, what do you want from me?\"  Pete tells Griff that you're my problem and tells him, \"I want to wake up next to you, read the newspaper, and maybe go out on a date.\"  Griff realizes that Pete is ready to break up with him so Griff quickly agrees to go on a date with Pete.\nGriff is annoyed to discover that Pete has tricked him into meeting at a gay coffeehouse. He runs into Sam, an out, loud, and proud activist, who is passing out flyers for a \"community action patrol\" to help prevent gay bashing. The juxtaposition of \"closeted\" and \"out\" gay people heightens the drama and serves as comic relief at the same time. The \"date\" ends with Griff telling Pete that he wants no part of the lifestyle displayed by the coffeehouse's clientele. They both leave and separate in anger with Pete walking up a dark alley and Griff getting into his Jeep. Griff then notices a black truck, going up the alley after Pete.",
+          "context_id": "fdbb4fca29515dc86960aed1e6ce24ee50017bf5",
+          "qas": [
+            {
+              "question": "What is the full name of the person inviting Gretchen to a fraternity party?",
+              "id": "c9535458a6a61c5f09698b49d5379fc48a40390e",
+              "answers": [
+                {
+                  "text": "John \"Griff\" Griffith",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Envy (2004 film)",
+      "url": "https://en.wikipedia.org/wiki/Envy_(2004_film)",
+      "paragraphs": [
+        {
+          "context": "Tim Dingman and Nick Vanderpark are best friends, neighbors and co-workers at 3M. Nick is constantly coming up with crazy ideas to get rich quick, and when he invents Vapoorize, a spray that instantly disintegrates dog feces, he actually succeeds. As Nick's wealth continues to grow, so does Tim's envy, as he had initially scoffed at the idea and squandered an opportunity to invest and become mega-rich himself. Nick is blissfully unaware of Tim's jealousy, and his generosity only serves to make Tim more envious of him. Meanwhile, Nick's wife Natalie decides to run for state senate but is continually plagued by questions about her husband's product.\nAfter Tim's wife Debbie and children temporarily leave and he is fired from 3M, Tim's jealousy reaches new levels. In a bar, he meets J-Man, a bizarre drifter, who lends a sympathetic ear and offers advice. After a drunken night out, Tim accidentally kills Nick's beloved horse, Corky, and buries the horse in his abandoned swimming pool.\nNick offers a $50,000 reward for the return of his horse. J-Man and Tim concoct a plan whereby J-Man would discover the horse and claim the reward, splitting the proceeds. However a series of unfortunate events, including Tim's family getting holed up in J-Man's mountain cabin, leads to the horse's carcass being lost in a rain storm.\nNick reveals to Tim that he is going to Rome for the debut of Vapoorize there, and gives Tim the opportunity to join him in a 50-50 partnership, which he accepts. J-Man finds out that Tim is now rich, and, feeling betrayed, tries to blackmail him. After confessing to his wife, now enjoying her rich lifestyle, Tim agrees to pay J-Man; however, J-Man ups his demands and asks to be Tim's partner. Tim accidentally shoots him in the back with an arrow and J-Man, believing that Tim has tried to kill him, backs down in fear.",
+          "context_id": "c8e6d49997a54ca38fd491449cca963f0e7ff647",
+          "qas": [
+            {
+              "question": "Who is the wife of the best friend of the man who does not invest in Vapoorize?",
+              "id": "9e4f7d977b37771e489f45e6e483fdc2dc534814",
+              "answers": [
+                {
+                  "text": "Natalie",
+                  "answer_start": 547
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who's wife leaves them after they are fired?",
+              "id": "4b2b139d23c0653631a23d217b949342fb2c3176",
+              "answers": [
+                {
+                  "text": "Tim",
+                  "answer_start": 662
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person that the man who owns the cabin try to blackmail?",
+              "id": "2f3aa22999cd4d78847f2481d6625367450a674c",
+              "answers": [
+                {
+                  "text": "Tim",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Uncle Buck",
+      "url": "https://en.wikipedia.org/wiki/Uncle_Buck",
+      "paragraphs": [
+        {
+          "context": "Bob and Cindy Russell and their three children, 15-year-old Tia, 8-year-old Miles, and 6-year-old Maizy, have recently moved from Indianapolis to the Chicago suburbs due to Bob's promotion. Late one night, they receive a phone call from a relative in Indianapolis informing them that Cindy's father has had a heart attack. They make plans to leave immediately to be with him. After hearing the news, Tia, bitter about having been forced to move, accuses Cindy of abandoning her father.\nBob suggests asking his brother, Buck, to come and watch the children, to which Cindy objects. They are middle-class suburbanites, whereas Buck is unemployed. He lives in a small apartment in Chicago, drinks and smokes cigars, and earns his living by betting on rigged horse races. He drives a dilapidated 1977 Mercury Marquis Brougham Coupe that pours smoke and backfires. His girlfriend, Chanice, owns an automobile tire shop. Buck and Chanice have been together for eight years; she wants to get married and start a family, and Buck has grudgingly accepted a new job at her shop. Since no-one else is available to help Bob and Cindy, they have no choice but to turn to Buck. Buck cheerfully informs Chanice that he can't start his job yet due to the family emergency. Chanice thinks Buck is trying, as usual, to lie his way out of working.",
+          "context_id": "6b39d4c86670043e5bb368ac0b2b9a175d88f53f",
+          "qas": [
+            {
+              "question": "What is the name of the child that Bob and Cindy had last? ",
+              "id": "e08dfa534675b2f8962e7a371b2d394ab76cd390",
+              "answers": [
+                {
+                  "text": "Maizy",
+                  "answer_start": 98
+                }
+              ]
+            },
+            {
+              "question": "Who do Bob and Cindy leave to be with?",
+              "id": "7a6ba44ec63ca47ae85110144574934f63d5067d",
+              "answers": [
+                {
+                  "text": "Cindy's father",
+                  "answer_start": 284
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Don't Knock Twice (film)",
+      "url": "https://en.wikipedia.org/wiki/Don%27t_Knock_Twice_(film)",
+      "paragraphs": [
+        {
+          "context": "Jess, an American sculptor, meets with her estranged daughter Chloe and invites her to come live with her and her husband, a wealthy banker named Ben. Chloe refuses the offer. That night, she goes out with her friend Danny to a neighborhood empty of homes except for one, where legend says a demonic witch lives. The two knock twice on the door and leave. Upon returning home, Danny starts experiencing strange paranormal occurrences. The disturbances stop when Chloe video calls Danny. Before they can converse, Chloe hears knocks on her door and when she leaves to answer them, Danny is seen in the video being dragged by an unseen force. When the demonic spirit frightens Chloe in her foster home, she accepts Jess' offer and moves in with her and Ben.\nChloe is initially hostile to her family and only plans to stay for a few nights. Strange events start to unfold, beginning when Chloe finds a human molar in her Coriander soup. Jess is suffering from a nightmare about an old woman crying in her house. In her nightmare, the woman looks at Jess and says, \"Przepraszam\" then slit her own throat, which scares Jess awake. Jess tells Chloe about her dream and finding this description familiar, Chloe tells Jess about a woman they nicknamed \"Ginger\", a supposed witch that used to live next door. After her death by suicide, they began the urban legend that she would come and get you if you knocked twice on her door. Jess dismisses this as a bad dream. While sculpting, Jess' model Tira is disturbed by Chloe's presence and leaves, claiming that there is darkness around her. Chloe believes that it is Baba Yaga haunting her, but she is ignored by Jess.",
+          "context_id": "137d56121fa0f6881f58277ef75ed9872fa7c2c3",
+          "qas": [
+            {
+              "question": "Whose offer does Chloe refuse?",
+              "id": "8b3f486a3ae19ac161e9e2e749cdc1375308c897",
+              "answers": [
+                {
+                  "text": "Jess",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Adore (The Smashing Pumpkins album)",
+      "url": "https://en.wikipedia.org/wiki/Adore_(The_Smashing_Pumpkins_album)",
+      "paragraphs": [
+        {
+          "context": "The Smashing Pumpkins had cemented their place as a cultural force with the multi-platinum Mellon Collie and the Infinite Sadness. Feeling the limitations of their guitar-driven hard rock sound, the band had started to branch out during the making of Mellon Collie, and, after the chart-topping success of the electronic-leaning \"1979\", the band zeroed in on electronica.\nAs the sprawling and massively successful Infinite Sadness tour wound down, Billy Corgan found himself facing many difficult issues, including musical burnout, the absence of his \"best friend and musical soul mate in the band\" Jimmy Chamberlin, the end of his marriage, and the death of his mother to cancer.During this period, the band released two new singles on movie soundtracks\u2014\"Eye\" and \"The End Is the Beginning Is the End\". Both songs incorporated electronic elements, yet retained the hard rock elements of the band's previous material; one reviewer called the two singles \"balls-out, full-energy chargers\" and wrote off the Pumpkins' previous remarks that the upcoming album would \"rock\" less. However, the new album material Corgan was writing consisted mainly of simple acoustic songs. Corgan, James Iha, D'arcy Wretzky, and Matt Walker spent a few days in the studio in February 1997 laying down demos mostly as live takes, and the band hoped to quickly record an entire album in such a manner. Corgan, hoping to maintain the band's progressive rock-inspired experimentation, soon had second thoughts about this approach and began envisioning a hybrid of folk rock and electronica that was at once \"ancient\" and \"futuristic\".",
+          "context_id": "a1d3d7c06bc6ddee76b6caa4623c1ea22db8f2c3",
+          "qas": [
+            {
+              "question": "What was the last name of Corgan's best friend?",
+              "id": "291f26b8fd570c6c90468c6c665ed8c9cead57ac",
+              "answers": [
+                {
+                  "text": "Chamberlin",
+                  "answer_start": 605
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Witness Chair",
+      "url": "https://en.wikipedia.org/wiki/The_Witness_Chair",
+      "paragraphs": [
+        {
+          "context": "Late one night, secretary Paula Young leaves the office of her boss, Stanley Whittaker (Douglas Dumbrille, locking the door and taking the stairs to avoid being seen by the elevator operator. The next morning, the cleaning lady finds Whittaker's dead body, an apparent suicide. Police Lieutenant Poole finds a letter signed by Whittaker in which the deceased states he embezzled $75,000. Soon, however, he suspects otherwise and, after investigating, arrests widower James \"Jim\" Trent, the vice president of Whittaker Textile Corporation. The gun that fired the fatal shot belongs to Trent, and the typewritten suicide note, though signed by Whittaker, specifically states that Trent is not involved in the embezzlement.\nThe trial goes badly for the defendant. The elevator operator recalls seeing only  Whittaker and Trent in the office building that night, and Martin, the prosecuting attorney, produces a possible strong motive: Trent's daughter Connie intended to run away with Whittaker that night. However, Paula interrupts the proceedings to claim responsibility for the crime. She had guessed that Whittaker intended to flee the country with Connie (she being unaware of his embezzlement) when two ship tickets were delivered to the office. With strong, concealed feelings for Trent, Paula forced Whittaker at gunpoint to sign the confession she had typed. However, Whittaker then tried to grab the gun, only to be fatally shot in the struggle. Trent asks Paula to marry him.",
+          "context_id": "08e3f466e87a30f3f9ff445fee03032ff604813c",
+          "qas": [
+            {
+              "question": "Who did the victim intend to run away with?",
+              "id": "a3cf930901be27a76c27c0126c2e7dfdc53a31e3",
+              "answers": [
+                {
+                  "text": "Connie",
+                  "answer_start": 949
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Bath, Somerset",
+      "url": "https://en.wikipedia.org/wiki/Bath,_Somerset",
+      "paragraphs": [
+        {
+          "context": "Bath once had an important manufacturing sector, particularly in crane manufacture, furniture manufacture, printing, brass foundries, quarries, dye works and Plasticine manufacture, as well as many mills. Significant Bath companies included Stothert & Pitt, Bath Cabinet Makers and Bath & Portland Stone.\nNowadays, manufacturing is in decline, but the city boasts strong software, publishing and service-oriented industries, being home to companies such as Future plc and London & Country mortgage brokers. The city's attraction to tourists has also led to a significant number of jobs in tourism-related industries. Important economic sectors in Bath include education and health (30,000 jobs), retail, tourism and leisure (14,000 jobs) and business and professional services (10,000 jobs). Major employers are the National Health Service, the city's two universities, and the Bath and North East Somerset Council, as well as the Ministry of Defence although a number of MOD offices formerly in Bath have recently moved to Bristol. Growing employment sectors include information and communication technologies and creative and cultural industries where Bath is one of the recognised national centres for publishing, with the magazine and digital publisher Future plc employing around 650 people. Others include Buro Happold (400) and IPL Information Processing Limited (250). The city boasts over 400 retail shops, half of which are run by independent specialist retailers, and around 100 restaurants and cafes primarily supported by tourism.",
+          "context_id": "7741312baf1b3b07e671be4750e7ac34756e3730",
+          "qas": [
+            {
+              "question": "What is the name of the place that has over 400 retail shops?",
+              "id": "b4d1458697a45d643e671eb17e409a8ec2c16cd2",
+              "answers": [
+                {
+                  "text": "Bath",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the place that attraction to tourists has also led to a significant number of jobs in tourism-related industries?",
+              "id": "9dfbd682a6a55329be8b40a5e5d21cde966e2d93",
+              "answers": [
+                {
+                  "text": "Bath",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "The heart of the Georgian city was the Pump Room, which, together with its associated Lower Assembly Rooms, was designed by Thomas Baldwin, a local builder responsible for many other buildings in the city, including the terraces in Argyle Street and the Guildhall. Baldwin rose rapidly, becoming a leader in Bath's architectural history. In 1776 he was made the chief City Surveyor, and Bath City Architect. Great Pulteney Street, where he eventually lived, is another of his works: this wide boulevard, constructed around 1789 and over 1,000 feet (305 m) long and 100 feet (30 m) wide, is lined on both sides by Georgian terraces.In the 1960s and early 1970s some parts of Bath were unsympathetically redeveloped, resulting in the loss of some 18th- and 19th century buildings. This process was largely halted by a popular campaign which drew strength from the publication of Adam Fergusson's The Sack of Bath. Controversy has revived periodically, most recently with the demolition of the 1930s Churchill House, a neo-Georgian municipal building originally housing the Electricity Board, to make way for a new bus station. This is part of the Southgate redevelopment in which an ill-favoured 1960s shopping precinct, bus station and multi-storey car park were demolished and replaced by a new area of mock-Georgian shopping streets. As a result of this and other changes, notably plans for abandoned industrial land along the Avon, the city's status as a World Heritage Site was reviewed by UNESCO in 2009. The decision was made to let Bath keep its status, but UNESCO has asked to be consulted on future phases of the Riverside development, saying that the density and volume of buildings in the second and third phases of the development need to be reconsidered. It also demands Bath do more to attract world-class architecture in new developments.",
+          "context_id": "a07b72f612b562a532de8061be6677d6a04cbab3",
+          "qas": [
+            {
+              "question": "What two rooms were designed by Thomas Baldwin?",
+              "id": "2d6561c83c44eb69c601bec5fdc0566911ce238a",
+              "answers": [
+                {
+                  "text": "the Pump Room",
+                  "answer_start": 35
+                },
+                {
+                  "text": "Lower Assembly Rooms",
+                  "answer_start": 86
+                }
+              ]
+            },
+            {
+              "question": "What was the last name of the person who became the chief City surveyor and Bath City Architect?",
+              "id": "be7d40bcd0274da120ba869327e1b1c85ff69cbc",
+              "answers": [
+                {
+                  "text": "Baldwin",
+                  "answer_start": 131
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Posse from Hell",
+      "url": "https://en.wikipedia.org/wiki/Posse_from_Hell",
+      "paragraphs": [
+        {
+          "context": "In 1880 four escapees from death row, Crip, Leo, Chunk and Hash ride into the town of Paradise and enter the Rosebud Saloon.  Crip shoots the town marshal Isaac Webb and takes ten men as hostages, killing some to ensure the four are unmolested.  The gang leaves town with $11,200 from the Bank of Paradise and a female hostage Helen Caldwell who entered the bar because her alcoholic Uncle Billy was one of the captives.\nPrior to these events, Marshal Webb had sent for a friend and former gunfighter Banner Cole to be his deputy. He takes Webb's place in leading a posse to rescue Helen and bring the men to justice.  Cole is a loner with a big reputation as a gunman.  He rides into a town marked by the gang's rampage, and is enraged to discover that the townspeople have put Webb on a table next to the three dead bodies of those murdered by the four.  The doctor said at first they thought Webb was dead himself, then realized he couldn't be moved.\nWebb's last act is to deputize Cole, telling him to do the right thing, not out of hate, but out of liking people, as the townsfolk are good people who have been badly hurt.  Cole agrees only out of liking Webb.  He makes his original plan for hunting down the four by himself clear by turning down the offer of Webb's handcuffs by saying \"I won't be needing any.\" However, town elder Benson convinces Cole to follow Webb's wishes and organize a posse.\nThe men of the town gather but enthusiasm wanes when not as many able bodied men as expected volunteer to go up against the killers, some men leaving because the posse doesn't outnumber the killers by ten to one.  Cole's frank assessment of the situation scares others off with Cole saying \"If they're afraid of words they shouldn't go.\"",
+          "context_id": "5c1d08f8b06e8155a2497cfc1705390793267476",
+          "qas": [
+            {
+              "question": "What is the first name of the man that hired the former gunfighter that leads the posse?",
+              "id": "fbb1766320e5f62d2c4ba891ac0e69f6f6d30012",
+              "answers": [
+                {
+                  "text": "Isaac",
+                  "answer_start": 155
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person that couldn't be moved from the table?",
+              "id": "952fd2f46fb2230c2ab1f84f00fad65f03a79ac0",
+              "answers": [
+                {
+                  "text": "Webb",
+                  "answer_start": 452
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person that doesn't need handcuffs?",
+              "id": "45c3ea04dcd6a5b045a0258e1ca25ee7cacc6464",
+              "answers": [
+                {
+                  "text": "Cole",
+                  "answer_start": 1129
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Wing Commander (film)",
+      "url": "https://en.wikipedia.org/wiki/Wing_Commander_(film)",
+      "paragraphs": [
+        {
+          "context": "It is the year 2654 and an interstellar war is raging between the Terran Confederation and the Kilrathi Empire. The cat-like Kilrathi seek the complete eradication of the human race.\nA massive Kilrathi armada attacks Pegasus Station, a remote but vital Confederation base, and captures a navigation computer, through which it will be able to locate Earth. Admiral Geoffrey Tolwyn recalls the Terran fleet to defend Earth, but expects it to arrive two hours too late. Tolwyn orders Lieutenant Christopher Blair, whose father he knew from a previous conflict called the Pilgrim Wars, to carry orders to the Tiger Claw, under the command of Captain Jason Sansky, to fight a suicidal delaying action to buy the needed time.\nLieutenants Blair and Todd Marshall are pilots fresh out of training, traveling aboard the small supply ship Diligent, commanded by Captain James Taggart, to their new posting aboard the carrier TCS Tiger Claw in the Vega Sector. En route, the ship gets pulled into a gravity well and loses its navigation computer. While Taggart repairs it, Blair is able to space-jump them to safety, calculating the jump in under ten seconds. Taggart notes that Blair outperformed the computer.",
+          "context_id": "ab24c451f3d3dfea7c0385a7ddc04ba6cc97bb43",
+          "qas": [
+            {
+              "question": "What is the full name of the person who knew Blair's father from the Pilgrim Wars?",
+              "id": "af54166391b8a79d045fef7bc44ec398158ea28b",
+              "answers": [
+                {
+                  "text": "Admiral Geoffrey Tolwyn",
+                  "answer_start": 356
+                }
+              ]
+            },
+            {
+              "question": "What loses its navigation computer after getting pulled into a gravity well?",
+              "id": "5bb7fc61f3680cf433af370f3ff050c6f0092650",
+              "answers": [
+                {
+                  "text": "the small supply ship Diligent",
+                  "answer_start": 807
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "One Hot Minute 0",
+      "url": "https://en.wikipedia.org/wiki/One_Hot_Minute",
+      "paragraphs": [
+        {
+          "context": "One Hot Minute was not as universally well received as Blood Sugar Sex Magik, and was ultimately considered to be a poor follow-up. It did however receive mixed to positive reviews from critics. Daina Darzin of Rolling Stone said \"One Hot Minute dives into the emotionally deep end of drug addiction and loss\", and that the album \"is a ferociously eclectic and imaginative disc that also presents the band members as more thoughtful, spiritual\u2014even grown-up. After a 10 plus-year career, they're realizing their potential at last.\" David Browne of Entertainment Weekly said that \"One Hot Minute wails and flails like a mosh-pit workout tape, but it also has moments of outright subtlety and maturity.\" He goes on to praise Kiedis for \"keeping his boorish tendencies under control.\" Browne, however, criticizes the band for \"attempts at cosmic philosophy which often trip up on hippie-dippie sentiments\", and some songs \"fall back on tired frat-funk flop sweat.\" \"The Peppers work their own little patch with considerable expertise,\" wrote Peter Kane in Q. \"The incoming Navarro rarely fails to deliver the goods and upfront the taut ball of energy going by the name of Anthony Kiedis still makes for a suitably rubbery-lipped frontman, if not exactly a lovable one.\" Q also included One Hot Minute in its 'best of the year' roundup: \"A bulging, blistering blend of a skewed ballads and physically intimidating workouts that charge around like a bull on a promise.\"AllMusic's Stephen Thomas Erlewine said that \"following up Blood Sugar Sex Magik proved to be a difficult task for the Red Hot Chili Peppers\", and \"Navarro's metallic guitar shredding should have added some weight to the Chili Peppers' punk-inflected heavy-guitar funk, but tends to make it plodding.\" Erlewine went on to add that \"by emphasizing the metal, the funk is gradually phased out of the blend, as is melody.\" Robert Christgau gave the album a rating of \"dud\".\"My Friends\" was considered by Erlewine to be a blatant attempt to hold on to the mainstream audience gained by \"Under the Bridge\", and that in contrast, \"the melodies are weak and the lyrics are even more feeble.\" The song also \"tries to be a collective hug for all [of Kiedis's] troubled pals.\" Rolling Stone, on the other hand, said the song was \"lovely\", and incorporated a \"vaguely folky chorus, and sports the same sad wishfulness of 'Under the Bridge' and 'Breaking the Girl'.\" The article went on to praise \"Warped\" claiming it \"mixes harrowing lyrics with a multi-toned, layered intro and a whirling dervish of noises and big-rock rhythms surfing through and over big, funky hooks. It's like, well, a drug rush.\" Rolling Stone went on to say that the title track was \"funky and fun. It's about love and sex. What the hell. Some things don't have to change.\" Entertainment Weekly said \"some of these songs last a little too long and could have benefited from a trimming\", though they credited Kiedis for sounding \"nearly spiritual\" on \"Falling into Grace\".",
+          "context_id": "951ccc6283bb3a782d43eea9b5dfaf936ebad5cb",
+          "qas": [
+            {
+              "question": "What is the full name of the band whose members, according to Daina Darzin, are presented as more thoughtful, spiritual -- even grown up -- by One Hot Minute?",
+              "id": "7ed72d58214c28c74737e5b0e629f42fcd917146",
+              "answers": [
+                {
+                  "text": "Red Hot Chili Peppers",
+                  "answer_start": 1583
+                }
+              ]
+            },
+            {
+              "question": "What is the title of the song described in a Rolling Stone article as \"like, well, a drug rush\"?",
+              "id": "ee9814784f09e20f9e2406c3df20f19710839f85",
+              "answers": [
+                {
+                  "text": "Warped",
+                  "answer_start": 2450
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Native Son (2010 film)",
+      "url": "https://en.wikipedia.org/wiki/Native_Son_(2010_film)",
+      "paragraphs": [
+        {
+          "context": "John, played by Sean Harris, lives in a remote area of Scotland.  The primary industry is potato farming and John is a picker who lives for the harvests; it is his outlet and all he has in his life. He yearns for contact, but is so self-conscious that he comes across as awkward and skittish.  His other outlet is watching people who live a life that he does not know how to make for himself, a life of home and family. John does not know how to act when a female co-worker shows interest in him.  John exhibits all the signs of someone who has suffered untold tragedies in his life.While driving back to town on a dark and isolated road, John comes upon a car stopped up ahead. He immediately sees a hose attached to the exhaust pipe. He has come upon a suicide by carbon monoxide and tries to help, but the woman is already dead.  Suddenly, headlights appear in the opposite direction and John's immediate reaction is to hide the body, though he has done nothing wrong. John is like one who feels blame for every event, even those for which there is no blame. That decision leads John to take the body of the dead young woman to a shed in the woods. Now John finds the intimacy and physical contact he so desperately craves.\nEarly the next morning, John is awakened to hear the sounds of police combing the woods calling his name. He has overslept. He quickly throws on some clothes and begins to run through the woods, but townspeople have now taken up the search for John. He runs at first, but he suddenly gives up trying to escape his pursuers and turns to face them, looking skyward. The townspeople have found him first. He knows his fate, and the townspeople club him before the police arrive.\nIn his final moments, the policewoman who first comes upon John touches his head to examine his wounds and strokes his wounded forehead as he dies from the clubbing. It may have been the only gentle touch that John has known.",
+          "context_id": "4bb1db6069c2ef6ba4511db42006d0cf1a43531f",
+          "qas": [
+            {
+              "question": "Who gives up?",
+              "id": "28c2504f39fabc7e9715e4fa28f931f22bc15e3f",
+              "answers": [
+                {
+                  "text": "John",
+                  "answer_start": 1251
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Dangerous (film)",
+      "url": "https://en.wikipedia.org/wiki/Dangerous_(film)",
+      "paragraphs": [
+        {
+          "context": "Don Bellows, a prominent New York architect, is engaged to the beautiful and wealthy Gail Armitage when he meets down-and-out Joyce Heath, who was once the most promising young actress on Broadway. Don feels deeply indebted to Joyce because her performance as Juliet inspired him to become an architect.\nWhile rehabilitating her, Don falls in love with the tempestuous actress. Joyce, convinced she destroys anything and anyone she touches, warns him she is a jinx. Compelled to save her, Don breaks his engagement to Gail and risks his fortune to back the actress in a Broadway show. Before opening night, he insists they marry, but Joyce resists his proposal, hiding the fact she is married to Gordon Heath, an ineffectual but devoted man who was financially ruined by their marriage.\nJoyce goes to Gordon and begs him for a divorce. When he refuses, she causes an automobile accident that cripples him for life. Her own injuries keep her from opening in the show, which fails. Don is ruined, and when he learns that Joyce has deceived him, he accuses her of being a completely selfish woman, her only true jinx.\nJoyce briefly considers suicide, but eventually sees the truth in Don's accusation. She re-opens the show and, although she truly loves Don, sends him away to marry Gail. The show is a success, and Joyce, now dedicated to a responsible life, goes to visit Gordon and salvage her marriage.",
+          "context_id": "c0481f0b420e7c65d455d3938a9a76641f16717c",
+          "qas": [
+            {
+              "question": "What's the last name of the man who is adamant that Joyce marry him?",
+              "id": "90b6ce6e79929a98cec8824fe45018b2dc2df699",
+              "answers": [
+                {
+                  "text": "Bellows",
+                  "answer_start": 4
+                }
+              ]
+            },
+            {
+              "question": "What's the full name of the person that falls in love with the former Broadway star?",
+              "id": "791954b3f46713c04a05089bd015d3b1d514ee97",
+              "answers": [
+                {
+                  "text": "Don Bellows",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What's the full name of the person that Gail's fiance leaves her for?",
+              "id": "221b827f5f5487a0b7785fcf26e344eb5d50a828",
+              "answers": [
+                {
+                  "text": "Joyce Heath",
+                  "answer_start": 126
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Blackwater Fire of 1937 3",
+      "url": "https://en.wikipedia.org/wiki/Blackwater_Fire_of_1937",
+      "paragraphs": [
+        {
+          "context": "The fatalities on the Blackwater Fire led the federal government to initiate their earliest rigorous investigation on such an event. The USFS investigation of the Blackwater fire incident was led by David Godwin, Assistant Chief of Fire Control for the USFS. His conclusions were that the firefighters were in good physical condition and most had some experience fighting forest fires. Godwin also determined that the managers on the incident were all fully trained and experienced firefighting professionals. Godwin stated that no fault should be assigned to the fire managers as the situation was beyond their control. He indicated that because of the distances involved in getting enough manpower to combat the fire while it was still relatively small (the Tensleep CCC crews had to travel 165 mi (266 km)), the fire was not contained enough to prevent the rapid spread that occurred when the weather front approached. Godwin's findings indicated that rapid deployment of firefighters was critical to successful fire suppression. These findings were reinforced by A. A. Brown, head of the Division of Fire Control in the Forest Service's Rocky Mountain Region, who studied the fire behavior and the responses to the Blackwater fire.\nIn an era when all fire was considered detrimental and with limited studies that documented the important ecological role of fire, immediate suppression using aggressive attack was considered the best way to protect the forests. Godwin believed that parachuting firefighters from airplanes as soon as fires were detected and as near to the fire as possible would provide the fastest way to get firefighters in place before a fire raged out of control. Consequently, by 1939 the first stages of the parachuting smokejumper program were initiated at Winthrop, Washington, and at two locations in Montana. A later review of 16 fatal fires, from the Blackwater Fire in 1937 through 1956, led managers of the USFS to implement the Ten Standard Firefighting Orders in 1957, which were later changed to FIREORDERS in 1987, with each letter designating one of the ten orders. Not long after the Ten Standard Firefighting Orders were implemented, 18 Watchout Situations were also developed to increase firefighter safety. Decades after the Blackwater Fire, forest managers had developed a better understanding of the ecological role of fire. Consequently, in 1977, the USFS dropped the 10 am rule from their firefighting strategic planning, and shifted their emphasis away from wildfire suppression to wildfire management.",
+          "context_id": "f14175510b9dd14bf56b8a2f084f35d52ae52719",
+          "qas": [
+            {
+              "question": "What is the first name of the person who stated that no fault should be assigned to the fire managers as the situation was beyond their control?",
+              "id": "c3ad8984f8a27966744fe4f5a73e496b48e2eba5",
+              "answers": [
+                {
+                  "text": "David",
+                  "answer_start": 199
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person whose findings indicated that rapid deployment of firefighters was critical to successful fire suppression?",
+              "id": "03c77304bd840a17e074c9692beae83b9fd208a5",
+              "answers": [
+                {
+                  "text": "David",
+                  "answer_start": 199
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Tribes (film)",
+      "url": "https://en.wikipedia.org/wiki/Tribes_(film)",
+      "paragraphs": [
+        {
+          "context": "Private Adrian, a young United States Marine Corps Vietnam war era draftee who, despite being an anti-war hippie, reluctantly reports to boot camp to fulfill his duty as an American.\nAdrian excels as a leader, though his pacifist ideology presents continuing conflicts between himself and his superiors.  Adrian's drill instructor, Gunnery Sgt. Thomas Drake quickly recognizes Adrian's leadership qualities, but is conflicted as he grows to respect Adrian while also realizing that he represents everything Adrian opposes. At one point, Adrian points out that his love of meditation is similar to Drake's drawing to relax, indicating a sketch of a flying bird. Both are ways of finding freedom. Drake responds angrily, denying that he had drawn the picture.\nThroughout the training, the Chief Drill Instructor, and Drake's superior, Master Sgt. Frank DePayster, takes an instant dislike to Adrian.  He repeatedly argues with Drake about him, claiming that the fact that the man is performing all of his assigned tasks is not enough. He considers Adrian's attitude grounds enough for him to be set back and placed in the Motivational Platoon, a disciplinary unit for problem recruits.  Drake disagrees and allows Adrian to continue training through to graduation, at one point personally bringing him back after he deserted. However, DePayster had gone behind Drake's back by filing a complaint against them both with the Company Commanding Officer.  Without Drake's approval, the CO removed Adrian, placing him in the Motivational Platoon under DePayster.  Drake accuses DePayster of carrying out a personal vendetta, to which DePayster replies \"I'll forget I heard that.\" \nDrake takes the drawing of the bird from his desk drawer and hangs it up, thus signifying his own method of rebellion and freedom.  The platoon graduates without Adrian. As Drake awaits a new batch of recruits, DePayster informs him that Adrian went \"over the hill\" during the night.",
+          "context_id": "ec9c47149960e72e8005576c9dc3b2c670b4d48e",
+          "qas": [
+            {
+              "question": "What were the full names and ranks of the 2 people who disagreed about Private Adrian's potential?",
+              "id": "276ce6fe6a2cf2e319d896e60b2a94b9f862621f",
+              "answers": [
+                {
+                  "text": "Master Sgt. Frank DePayster",
+                  "answer_start": 833
+                },
+                {
+                  "text": "Gunnery Sgt. Thomas Drake",
+                  "answer_start": 332
+                }
+              ]
+            },
+            {
+              "question": "Who places Adrian in the Motivational Platoon which is disciplinary unit for problem recruits?",
+              "id": "f9bb32bc2a79a823bf853ec2904ca2e74bca9d69",
+              "answers": [
+                {
+                  "text": "the Company Commanding Officer",
+                  "answer_start": 1417
+                }
+              ]
+            },
+            {
+              "question": "What does Drake hang up to signify his own method of rebellion and freedom?",
+              "id": "f66874a345869a838b16b20c103b7edd055c56e1",
+              "answers": [
+                {
+                  "text": "sketch of a flying bird",
+                  "answer_start": 636
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person who denies that they had drawn a picture?",
+              "id": "90d997b5c96a5c0348fd066433450a9ec7eee164",
+              "answers": [
+                {
+                  "text": "Thomas Drake",
+                  "answer_start": 345
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Dead Man",
+      "url": "https://en.wikipedia.org/wiki/Dead_Man",
+      "paragraphs": [
+        {
+          "context": "William Blake, an accountant from Cleveland, Ohio, rides by train to the frontier company town of Machine to take up a promised accounting job in the town's metal works. During the trip, the train Fireman warns Blake against the enterprise. Arriving in town, Blake discovers that the position has already been filled, and he is driven from the workplace at gunpoint by John Dickinson, the ferocious owner of the company. Jobless and without money or prospects, Blake meets Thel Russell, a former prostitute who sells paper flowers. He lets her take him home. Thel's ex-boyfriend Charlie surprises them in bed and shoots at Blake, accidentally killing Thel when she tries to shield Blake with her body. The bullet passes through Thel and wounds Blake, but he is able to kill Charlie using Thel's gun before dazedly climbing out the window and fleeing the town on Charlie's horse. Company-owner Dickinson is Charlie's father, and he hires three legendary frontier killers, Cole Wilson, Conway Twill, and Johnny \"The Kid\" Pickett to bring Blake back 'dead or alive'.",
+          "context_id": "dcb6dd9fc7b44a0aa4e19bd28072994b7026d742",
+          "qas": [
+            {
+              "question": "Who shields the accountant from death?",
+              "id": "63beb190d4f9a9bf98a86d7439c914fa365be109",
+              "answers": [
+                {
+                  "text": "Thel",
+                  "answer_start": 651
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the murdered son of the company owner?",
+              "id": "ee181180c321031e8e04805f54c535d21a1c7b10",
+              "answers": [
+                {
+                  "text": "Charlie",
+                  "answer_start": 774
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person that the former prostitute defends before her death?",
+              "id": "81ebf5244a46388949331c419ea474b646e225e3",
+              "answers": [
+                {
+                  "text": "William Blake",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Flight of the Intruder",
+      "url": "https://en.wikipedia.org/wiki/Flight_of_the_Intruder",
+      "paragraphs": [
+        {
+          "context": "Lieutenant Jake \"Cool Hand\" Grafton and his bombardier/navigator and best friend Lieutenant Morgan \"Morg\" McPherson are flying a Grumman A-6 Intruder over the Gulf of Tonkin towards North Vietnam. They hit their target, a 'suspected truck park', which actually turns out to be trees. On the return to carrier, Morg is fatally shot in the neck by an armed Vietnamese peasant. Landing on the USS Independence with Morg dead, a disturbed Jake, covered in blood, walks into a debriefing with Commander Frank Camparelli and Executive Officer, Commander \"Cowboy\" Parker. Camparelli tells Jake to put Morgan's death behind him and to write a letter to Sharon, Morg's wife. New pilot Jack Barlow, nicknamed \"Razor\" because of his youthful appearance, is then introduced.\nLieutenant Commander Virgil Cole arrives on board and reports to Camparelli, who later tells Jake's roommate Sammy Lundeen to take Jake, Bob \"Boxman\" Walkawitz and \"Mad Jack\" (Dann Florek) to fly into Subic Bay the next day and help Jake unwind. Jake goes to see Sharon, but she has already departed. He runs into a woman named Callie Troy, who is packing Sharon's things, and they have a small, tense encounter. After an altercation with civilian merchant sailors in the Tailhook Bar, Jake runs into Callie again. After they reconcile, dance and spend the night together, she reveals her husband was a Navy pilot himself and was killed on a solo mission over Vietnam.\nJake returns to the carrier, where Camparelli confronts him regarding the bar incident, and Cole reports in Jake's favor. Cole and Jake are paired on \"Iron Hand\" A-6Bs loaded with Standard and Shrike anti-radiation missiles for SAM suppression. During the mission, after a successful strike, they encounter and manage to evade a North Vietnamese MiG-17.",
+          "context_id": "cca9f3942894a25430057869adcfd3e01fa981f7",
+          "qas": [
+            {
+              "question": "What is the first name of the person who reveals their husband was killed on a solo mission over Vietnam?",
+              "id": "d8469ac400bd257ed45e30600ca7f41a9f2d50dd",
+              "answers": [
+                {
+                  "text": "Callie",
+                  "answer_start": 1264
+                }
+              ]
+            },
+            {
+              "question": "What are the first names of the people who dance and spend the night together after reconciling?",
+              "id": "c224be27b3323a225412be702e86e0a3427c14b0",
+              "answers": [
+                {
+                  "text": "Callie",
+                  "answer_start": 1091
+                },
+                {
+                  "text": "Jake",
+                  "answer_start": 1249
+                }
+              ]
+            },
+            {
+              "question": "What are the first names of the people who evade a North Vietnamese MiG-17?",
+              "id": "e6dd52ae6d4bc3d7e40b6533608b1ff8cb13205c",
+              "answers": [
+                {
+                  "text": "Jake",
+                  "answer_start": 1432
+                },
+                {
+                  "text": "Virgil",
+                  "answer_start": 784
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Flipped (film)",
+      "url": "https://en.wikipedia.org/wiki/Flipped_(film)",
+      "paragraphs": [
+        {
+          "context": "In 1957, when second-graders Bryce Loski and Julianna \"Juli\" Baker first meet, Juli knows it's love, but Bryce isn't so sure and tries to avoid Juli. By the sixth grade, in 1961, Bryce tries to get rid of Juli by dating Sherry Stalls, whom Juli despises. However, Bryce's best friend, Garrett, takes an interest in Sherry and eventually tells her the truth about Bryce asking her out; she doesn't take it well.\nFrom Juli's perspective, Bryce returned her feelings, but was shy. After finding out Bryce and Sherry broke up, she thought she could have Bryce back. But then they reconsider their decisions as time goes on.\nIn 1962, Bryce's grandfather Chet Duncan moves in with the family. Chet has different views about Juli. There's a large, old sycamore tree that Juli loves which no one else understands. One day, it's cut down by a group of landscapers so a house can be built there, despite Juli's opposition. She becomes very depressed afterwards, as the tree let her see the world in a more enlightened way. Her father gives her a painting of the tree.\nChet gets to know Juli while helping her work on her lawn. Bryce begins to develop feelings for Juli, who begins to have mixed feelings about him. When Juli finds out that Bryce has been throwing away the eggs she offered his family right under her nose, out of fear of salmonella, she feels hurt and starts avoiding him.\nAfter visiting her disabled uncle Daniel, Juli overhears Bryce supporting Garrett's badmouthing of her, which truly causes her to stop having any interest in him. When the Bakers are invited to the Loskis' for dinner, Juli confronts Bryce about what he said. During dinner, they sit opposite each other; she doesn't talk to Bryce or make eye contact with him. After dinner, she apologizes for her behavior. Bryce is confused and sad that she apologizes, because it means he isn't forgiven and she doesn't care enough to hold a grudge.",
+          "context_id": "0dd8f16dd513aba34d9fd7408fa80b111296e467",
+          "qas": [
+            {
+              "question": "What is the first name of the girl that the friend of Bryce takes an interest in?",
+              "id": "327dd4910643606589d3d329259f5ff5f76d07b7",
+              "answers": [
+                {
+                  "text": "Sherry",
+                  "answer_start": 315
+                }
+              ]
+            },
+            {
+              "question": "What is the nickname of the person that the grandfather of the boy who breaks up with Sherry get to know while working on the lawn?",
+              "id": "82bd9d467074e967a816587725274449a4bd816e",
+              "answers": [
+                {
+                  "text": "Juli",
+                  "answer_start": 1076
+                }
+              ]
+            },
+            {
+              "question": "Who is the uncle of the girl that is badmouthed by Bryce's friend?",
+              "id": "f0ad382fba53a2a2a9912c719c8fde97d98888cd",
+              "answers": [
+                {
+                  "text": "Daniel",
+                  "answer_start": 1414
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person that the girl ignores after overhearing him badmouth her?",
+              "id": "ce7764341fb50ee5e5ddcc969e2d1fdaf859cfb2",
+              "answers": [
+                {
+                  "text": "Bryce",
+                  "answer_start": 1437
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "\"City of Blinding Lights\"",
+      "url": "https://en.wikipedia.org/wiki/City_of_Blinding_Lights",
+      "paragraphs": [
+        {
+          "context": "\"City of Blinding Lights\" is a song by Irish rock band U2. It is the fifth track on their eleventh studio album, How to Dismantle an Atomic Bomb (2004), and was released as the album's fourth single on 6 June 2005. The song reached number one in Spain, and peaked in the top ten in Canada, Ireland, the United Kingdom, and several other countries. The music video was shot at the General Motors Place in Vancouver, British Columbia, Canada.\nThe earliest incarnation of the song was developed during sessions for the band's 1997 album, Pop. The lyrics were written by the band's lead vocalist Bono, taking partial inspiration from his recollection of his first trip to London, and from the band's experience playing in New York City in the aftermath of the September 11 attacks during their Elevation Tour in 2001. Other lyrics refer to Bono's relationship with his wife Ali. The song's underlying theme reflects lost innocence and was inspired by an image Bono saw of himself from the early 1980s. The sound has been compared to the tone of U2's 1984 album, The Unforgettable Fire and their 1987 single \"Where the Streets Have No Name.\"\n\"City of Blinding Lights\" was well received by critics and won a Grammy Award for Best Rock Song at the 2006 ceremony. The song made its live debut on the group's 2005-2006 Vertigo Tour, when it was commonly played as the opening song, and it has been performed at nearly every show from a U2 concert tour since. The track has been used in episodes of The Simpsons and Entourage, and in the film The Devil Wears Prada.\nFormer U.S. President Barack Obama used the song at his campaign events during the 2008 and 2012 U.S. presidential elections, and listed it as one of his favourite songs; U2 performed it at his 2009 inaugural celebration at the Lincoln Memorial.",
+          "context_id": "e1a8b474b8174893c55cccc0270a8c5dc8ddf7f5",
+          "qas": [
+            {
+              "question": "What is the name of the album that the band was making during the original creation of the song that reached number one in Spain?",
+              "id": "ef501d86014bbec3cebab00b2d2f60943ada4d66",
+              "answers": [
+                {
+                  "text": "Pop",
+                  "answer_start": 535
+                }
+              ]
+            },
+            {
+              "question": "What is the single that the the song that peaked in the top ten in Canada has been compared to?",
+              "id": "43eab8684decd83ba6ff73b95b0dfeba38bf6ac2",
+              "answers": [
+                {
+                  "text": "Where the Streets Have No Name",
+                  "answer_start": 1104
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "\"City of Blinding Lights\" is played in common time at a tempo of 139 beats per minute in two keys: A\u266d major in the verses, and E\u266d major in the chorus.\nThe album version of the song runs for 5:47. It begins with a low note played on an electric guitar with heavy delay and distortion. The note is sustained for ten seconds as its harmonics gradually feed back. A pulsing rhythm guitar part with muted staccato chords by the Edge then begins underneath. After a further ten seconds it is joined by lower-register guitar drones played by the Edge, and a repetition of four descending piano notes performed by the Edge and Bono. Forty-five seconds into the song, halfway through the introduction, Clayton's bass and percussion by drummer Larry Mullen, Jr. fade into the song with producer Jacknife Lee's synthesizers, which play part of the melody line. The first verse begins at 1:20 and is accompanied by the bass, drums and rhythm guitar playing the chord progression A\u266d\u2013E\u266d\u2013D\u266d. This alters to B\u2013D\u266d in the pre-chorus, with a short harmony vocal line leading to the E\u266d\u2013D\u266d chorus.After the second chorus, the lead guitar alternates with Bono's repeated \"Time\" into the B\u266d\u2013A\u266d bridge before returning to an extended chorus. The vocals range from D\u266d3 in the verses to a peak of C5 in the chorus. The Edge provides backing vocals in the second verse, the first three chorus lines, and the bridge lyric \"Time won't leave me as I am / Time won't take the boy out of this man\". There is no chorus after the third verse; instead, the track enters into a coda where, after restating the introductory piano theme, the guitar, bass, and drum parts come to a finish. The song concludes on a final reprise of the piano notes. The radio edit, with a run-time of 4:11, is 1:36 shorter than the album version. The introduction is half the length and the bass and drums enter after only two repetitions of the piano notes. The first two verses are kept intact but the bridge is shortened by seven seconds, removing two calls of \"Time.\" The third verse is cut and the coda shortened by twenty seconds.The sound of \"City of Blinding Lights\" has been compared to U2's 1987 single \"Where the Streets Have No Name,\" prompted by a similar style of guitar playing, as well as to the atmospheric tone of the band's 1984 album The Unforgettable Fire. The melding of guitar and piano in the introduction was likened by the Edmonton Journal to the Coldplay song \"Clocks.\" Rolling Stone described the song as \"building into a bittersweet lament\", while Uncut said it was \"beautiful but slightly sinister\", comparing the quality of the lyrics to the George Harrison song \"The Inner Light.\"",
+          "context_id": "50f8bf1174c6d16b8f382286af44c06dd8261fad",
+          "qas": [
+            {
+              "question": "What is the name of the band whose 1984 album was Unforgettable Fire?",
+              "id": "39ae06e9c71f14027b54e08fedc328d1fc2dbfa3",
+              "answers": [
+                {
+                  "text": "U2",
+                  "answer_start": 2139
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "The underlying theme of \"City of Blinding Lights,\" reflected in the chorus, is lost innocence. The theme was reinforced during an impromptu concert at Empire\u2013Fulton Ferry State Park under the Brooklyn Bridge; Bono introduced the song by reminiscing about the first time the band arrived in New York City, calling it \"a song about innocence and na\u00efvete.\" Bono developed the opening stanza from a memory of his first trip to London with his future wife, Alison Stewart, when they were teenagers. The experience of walking through Piccadilly Circus and along Wardour Street put him in mind of \"discovering what a big city could offer you and what it could take away.\" Although the first verse is set in London, the chorus is set in New York City. The verse, \"I've seen you walk unafraid / I've seen you in the clothes you've made / Can you see the beauty inside of me? / What happened to the beauty I had inside of me?\" was written as an expression of love for Alison, with a reflection on their life together as they grow older.Like many other U2 songs, \"City of Blinding Lights\" can be interpreted in a religious manner. Author Cameron Conant related the opening verse to the doubt he felt about his convictions on politics, marriage, and faith as he aged, concluding that a person's confidence in their beliefs makes it seem as if they know more than they do. Music critic Bill Friskics-Warren felt that the final line, \"Blessings not just for the ones who kneel, luckily\", was a way for Bono to berate himself for not praying enough, and was an attack on Christianity because \"faith often perpetuates the misery and divisiveness that he decries.\" Steve Stockman, a chaplain at Queen's University of Belfast, believed the song was a metaphor for growing up, and that the final line meant that not just people of faith could be blessed.",
+          "context_id": "b1dc9cbf5693b97c2ba4658eb9ec33b1078ad641",
+          "qas": [
+            {
+              "question": "What was the full name of the person that the verse \"I've seen you walk unafraid\" was written as an expression of love for?",
+              "id": "bbaae7743346bf9606505d2ac259b3fd0aa6e213",
+              "answers": [
+                {
+                  "text": "Alison Stewart",
+                  "answer_start": 452
+                }
+              ]
+            },
+            {
+              "question": "What was the first name of Bono's future wife?",
+              "id": "0a7fe03febc5353c264c83cc5964a49c6004f815",
+              "answers": [
+                {
+                  "text": "Alison",
+                  "answer_start": 452
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person took his first trip to London with his future wife?",
+              "id": "cd9523a577a3d2117817e23e44a3dbb1d9d864a4",
+              "answers": [
+                {
+                  "text": "Bono",
+                  "answer_start": 354
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "Reception to \"City of Blinding Lights\" was positive. Reviewing the album, Allmusic editor Stephen Thomas Erlewine said the song had \"huge melodic and sonic hooks\" and labelled it one of \"the ingredients that make How to Dismantle an Atomic Bomb a very good U2 record.\" Entertainment Weekly felt the song demonstrated the band's ability to \"make pop-chart lust work for them.\" Pitchfork Media reviewer Amanda Petrusich thought it was one of the album's highlights, calling it \"an earnest and galactic fight song, and the sort of track that's best enjoyed in cars and airplanes, simply because it encites  [sic] so much giddy movement.\"PopMatters opined, \"U2 sounds updated ... the bombast stays in check and Bono's questions sound earnest without being overzealous,\" though felt it \"lack[s] the musical and lyrical guts of 'Pride (In the Name of Love)' or 'Sunday Bloody Sunday.'\" Rating the song three stars out of five, Uncut reviewer Stephen Dalton wrote it was \"indebted to the sky-punching peaks, grand vistas and monochrome emotions of the band's 1980s albums\", deeming it a \"heart-stirring anthem.\" Peter Murphy called it \"the album's masterpiece\" in his review for Hot Press, describing the opening as \"little short of celestial.\" At the 48th Grammy Awards in 2006, \"City of Blinding Lights\" won the award for the Best Rock Song. In a 2010 survey conducted by fan site atU2.com, 1080 of 4814 participants (22.43%) labelled it their favourite song on the album, ranking it first on the list. Previous fan surveys in 2005, 2006, and 2007 had also ranked the song the most favoured from the album.",
+          "context_id": "648476ad47e4bc1f73e5ab998e02b675d4b65616",
+          "qas": [
+            {
+              "question": "What is the name of the person who wrote a review for Hot Press?",
+              "id": "11b4776096c1322393d7535354587927fd2dbc2b",
+              "answers": [
+                {
+                  "text": "Peter Murphy",
+                  "answer_start": 1105
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Smart Girls Don't Talk",
+      "url": "https://en.wikipedia.org/wiki/Smart_Girls_Don%27t_Talk",
+      "paragraphs": [
+        {
+          "context": "When small-time hood Johnny Warjack and his gang hold up the Club Bermuda, a nightclub/gambling den, he is recognized. Club owner Marty Fain orders his men to deal with Warjack and offers to make good his patrons' losses. Socialite Linda Vickers and gambler Nelson Clark both try to take advantage of Fain's generosity.  He does not believe either of them. Nonetheless, Fain deducts Clark's claimed $10,000 loss from his outstanding debts, but then demands the remaining $13,000 be paid within a week.\nAs for Vickers' $18,000 of stolen jewelry, she claims to have an insurance policy for that amount. Fain insists on seeing it, so they head for her apartment. The nightclub attendant says her car is parked far away, so Fain drives the woman home in his car. At her apartment, Vickers admits she lied. Fain is not surprised, having read of her financial troubles in the newspaper. They begin seeing each other.\nThe next morning, Vickers is awoken by police Lieutenant McReady. Warjack was found murdered, and her car was spotted at the scene. Vickers has an alibi and sees no reason to divulge her suspicions. When she tells Fain of McReady's visit and mentions her excellent memory, Fain writes her a check for $18,000. She later returns it uncashed and breaks up with him.\nHer brother, \"Doc\" (Robert Hutton), arrives in the city to take up a new medical job. He does not approve of his sister's boyfriend, though he does not mind being introduced by Fain to Toni Peters, the club's singer.",
+          "context_id": "e7af779fa4b10881b2ff0201221140a93e858cbc",
+          "qas": [
+            {
+              "question": "What does Linda claim Johnny's gang stole?",
+              "id": "59027b8722fc843a4ad0c1cf0b77bf66cfe3e07e",
+              "answers": [
+                {
+                  "text": "$18,000 of stolen jewelry",
+                  "answer_start": 518
+                }
+              ]
+            },
+            {
+              "question": "How much does Nelson still owe after the robbery?",
+              "id": "e09769cf298f1c882814bd10a6899b57fb1d1fc7",
+              "answers": [
+                {
+                  "text": "$13,000",
+                  "answer_start": 471
+                }
+              ]
+            },
+            {
+              "question": "What does Fain insist on seeing?",
+              "id": "f8684efa02ef01ebce3753b82317da39bf2aa703",
+              "answers": [
+                {
+                  "text": "an insurance policy",
+                  "answer_start": 564
+                }
+              ]
+            },
+            {
+              "question": "What are the last names of the people who being seeing each other?",
+              "id": "34ae7bc4c58b2a3751ba35c04421bf85dacecc10",
+              "answers": [
+                {
+                  "text": "Vickers",
+                  "answer_start": 777
+                },
+                {
+                  "text": "Fain",
+                  "answer_start": 802
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person that Vickers breaks up with?",
+              "id": "5362eaa201f7323e1fbc93f1ad2ba4538c24805c",
+              "answers": [
+                {
+                  "text": "Fain",
+                  "answer_start": 1184
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person who has a brother named \"Doc\"?",
+              "id": "c74dceb3a95ad703a8f98eb57b9f82fe20bbef55",
+              "answers": [
+                {
+                  "text": "Linda Vickers",
+                  "answer_start": 232
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who returns a check uncashed?",
+              "id": "929cf38cc155764111c02412729fe42e88f6e4e8",
+              "answers": [
+                {
+                  "text": "Vickers",
+                  "answer_start": 777
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Dracula: The Dark Prince",
+      "url": "https://en.wikipedia.org/wiki/Dracula:_The_Dark_Prince",
+      "paragraphs": [
+        {
+          "context": "Dracula, a Romanian prince, knight of the secret order of the dragon, and direct descendent of Abel is charged with the task of vanquishing the Turks from his homeland. While on campaign, he appoints his wife Elizabeth to rule in his place. When he returns however, he finds that his wife and knights have been murdered by his advisers who were unhappy with his ways- he kills them, spare one who remains loyal with the aid of a loyal squire (who is fatally wounded). An enraged Dracula turns against God, and is cursed to spend an eternity in loneliness.\nCenturies later, a group of keepers are attacked by a monstrous armoured figure known as Wrath and is undead, in their quest to find the Lightbringer- the only weapon that can kill Dracula. Sisters Alina and Esme are entrusted to bring the Lightbringer to Leonardo Van Helsing as their guards ward off an attack. \nA band of thieves led by Lucian finds the sisters and steal the Lightbringer. Leonardo arrives just before the band is attacked by Wrath and his undead. During the struggle, Lucien manages to activate the Lightbringer- revealing that he is a descendant of Cain, and able to wield the weapon. He manages to injure Wrath with the weapon but most of the thieves are killed, and Alina is kidnapped by Wrath and brought to Dracula.\nDracula recognizes Alina as his murdered bride and instructs his advisor Renfield to protect her. \nMeanwhile, Leonardo tells a sceptical Lucien about his lineage. The group discovers that the Lightbringer is activated by Lucien's blood to kill the undead, and Leonardo goes on to say that with the blood of Dracula, it could bring the dead to life. \nAt the castle, Alina attempts to leave but is stopped by one of the new residents, Demetria who shows her the dining room and says that they like living there. As she becomes entranced by the atmosphere, the courtiers, who are revealed to be vampires attempt to bite her, but Alina is rescued by Dracula just in time.",
+          "context_id": "91f574010f6b549bdb0741fc380e33c9f016b526",
+          "qas": [
+            {
+              "question": "Who is the man who turns against God a descendant of?",
+              "id": "2557a13b4e165bb7c7959821b0b0e540e8c91065",
+              "answers": [
+                {
+                  "text": "Abel",
+                  "answer_start": 95
+                }
+              ]
+            },
+            {
+              "question": "Who is the sister of the woman that is kidnapped by Wrath?",
+              "id": "63a057220fcd09a145b2752daacf0e4c11283cae",
+              "answers": [
+                {
+                  "text": "Esme",
+                  "answer_start": 764
+                }
+              ]
+            },
+            {
+              "question": "Who does Dracula appoint to protect the woman that is kidnapped?",
+              "id": "d70529a2fc64687a18fdaf388b92b31dddffee72",
+              "answers": [
+                {
+                  "text": "Renfield",
+                  "answer_start": 1370
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Onionhead",
+      "url": "https://en.wikipedia.org/wiki/Onionhead",
+      "paragraphs": [
+        {
+          "context": "In the spring of 1941, Al Woods quits an Oklahoma college to join the armed forces after a quarrel with his co-ed sweetheart, Jo. He joins the Coast Guard, partly by chance due to the flip of a coin.  After boot training, Al is assigned to a buoy tender in Boston, the Periwinkle, as a ship's cook although he has no cooking experience. He encounters immediate hostility from the chief of the galley, Red Wildoe, from new crew mates and cooks' helpers Gutsell and Poznicki, and from his arrogant department head, Lieutenant (junior grade) Higgins.\nIn a Boston bar, Al picks up Stella, who appears to do this kind of thing with some regularity. They develop a strong attraction, but she seems to be holding out for something more.  He befriends Gutsell by fixing him up with a girlfriend of Stella's and learns from Wildoe how to be a ship's cook, making a number of embarrassing mistakes. Al, frustrated after Stella won't spend a night in a hotel room with him, stops seeing her, whereupon he and the alcoholic Wildoe get drunk together and bond. Wildoe begins seeing Stella with Al's blessing.  Pearl Harbor is attacked and war declared.  Wildoe abruptly proposes to Stella and they marry. A free-for-all breaks out at their wedding celebration, with a jealous Al instigating a fight with soldiers who are clearly familiar with Stella already.  Wildoe is assigned to another vessel performing convoy duty at sea. During this time, Stella begins seeing other men. Al tries to prevent this on Wildoe's behalf, but can't resist Stella himself.",
+          "context_id": "e71e1eec0848e24a4648eb93d0ad1847b0dac171",
+          "qas": [
+            {
+              "question": "Who does the chief of the galley end up marrying?",
+              "id": "b8318f79ba19f2612eba942634a7be32259e3d9f",
+              "answers": [
+                {
+                  "text": "Stella",
+                  "answer_start": 910
+                }
+              ]
+            },
+            {
+              "question": "Where did Al Woods encounter hostility from his arrogant department head?",
+              "id": "344ac1266b8800fe42a508d33776b86a6aea76ed",
+              "answers": [
+                {
+                  "text": "the Periwinkle",
+                  "answer_start": 265
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Long Goodbye (film)",
+      "url": "https://en.wikipedia.org/wiki/The_Long_Goodbye_(film)",
+      "paragraphs": [
+        {
+          "context": "Late one night, private investigator Philip Marlowe is visited by his close friend Terry Lennox, who asks for a lift from Los Angeles to the California\u2013Mexico border at Tijuana. Marlowe obliges. On returning home, Marlowe is met by two police detectives, who accuse Lennox of having murdered his rich wife, Sylvia. Marlowe refuses to give them any information, so they arrest him. After he is jailed for three days, the police release him, because they have learned that Lennox has committed suicide in Mexico. The police and the press seem to believe it is an obvious case, but Marlowe does not accept the official facts.\nMarlowe is hired by Eileen Wade, the platinum-blonde trophy wife of Roger Wade, an alcoholic novelist with writer's block, whose macho, Hemingway-like persona is proving self-destructive. She asks that Marlowe find her missing husband. He has had regular alcoholic binges and days-long disappearances from their Malibu home in the past. In the course of investigating Mrs. Wade's missing husband, Marlowe visits the subculture of private detoxification clinics for rich alcoholics and drug addicts. He locates and recovers Roger Wade and learns that the Wades knew the Lennoxes socially. He suspects that there is more to Lennox's suicide and the murder of Sylvia. Marlowe incurs the wrath of gangster Marty Augustine, who wants money returned that Lennox owed him. Augustine maims his mistress to demonstrate what could happen to Marlowe, saying, \"That's someone I love. You, I don't even like.\"",
+          "context_id": "3ad6594af6f26dd4133cac6105a46afbbafffc53",
+          "qas": [
+            {
+              "question": "What is the full name of the person who is arrested?",
+              "id": "48bd2d1bfa7f6bd18bd8c22181ffe8b639e1cc59",
+              "answers": [
+                {
+                  "text": "Philip Marlowe",
+                  "answer_start": 37
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person who has had regular alcoholic binges?",
+              "id": "446d2bbb0ed1705939f9a9f30f6c9b8b11b09217",
+              "answers": [
+                {
+                  "text": "Roger Wad",
+                  "answer_start": 691
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person who has had days-long disappearances from their home in the past?",
+              "id": "79d171343705701bc9d796419d0f31076bac46fd",
+              "answers": [
+                {
+                  "text": "Roger Wade",
+                  "answer_start": 691
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person who suspects that there is more to a suicide and a murder?",
+              "id": "0d7287e62a69ad0f42f6f3d3f377395fdc252884",
+              "answers": [
+                {
+                  "text": "Philip Marlowe",
+                  "answer_start": 37
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Ladies They Talk About",
+      "url": "https://en.wikipedia.org/wiki/Ladies_They_Talk_About",
+      "paragraphs": [
+        {
+          "context": "Nan Taylor is a member of a gang of bank robbers, posing as a regular customer to distract the security guard while her accomplices take the money. Her cover is blown by a policeman who had arrested her before, and she is arrested. Reform-minded radio star, David Slade, falls in love with her and gets her released as a favor from District Attorney Simpson. However, when she confesses that she is guilty, Simpson has her imprisoned.\nAt San Quentin State Prison, Nan meets fellow inmates Linda, \"Sister Susie\", and Aunt Maggie, as well as prison matron Noonan. Slade continues to send Nan letters, but she refuses his entreaties. Meanwhile, Linda has a fancy for Slade, and resents Nan for spurring him. Her bank accomplice, Lefty, visits her, and tells her that Don is now imprisoned in the men's section on the other side of the wall. Lefty tells her to make a map of the women's section as well as a copy of the matron's key so that the men can escape via the women's section of the prison. However, Nan believes Slade told the prison officials about the escape plot and Don is shot dead as he gets to Nan's cell to break her out. Nan is given another year, and is not allowed visitors, but vows to seek revenge on Slade.\nWhen she is released, Nan goes to a revival group meeting hosted by Slade. He is glad to see her, and she is escorted to a back room where he professes his love for her. She scoffs and accuses him of turning in her bank robber accomplices. She shoots him but misses, hitting him in the arm. Sister Susie sees this from outside via a keyhole, but Slade denies that he has been shot, and Slade and Nan announce their intention to marry.",
+          "context_id": "23e3b68be3a29e507715d47cbf35c35079841669",
+          "qas": [
+            {
+              "question": "What is the full name of the person that the radio star is glad to see at the revivial group meeting?",
+              "id": "4b60b04f24cb4888bfbcd298fb8e21611f965667",
+              "answers": [
+                {
+                  "text": "Nan Taylor",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the profession of the person that Nan Taylor shoots in the arm?",
+              "id": "4e51107a66ad341f98523b1ea5307bc122a4c696",
+              "answers": [
+                {
+                  "text": "radio star",
+                  "answer_start": 246
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Lady in the Car with Glasses and a Gun (1970 film)",
+      "url": "https://en.wikipedia.org/wiki/The_Lady_in_the_Car_with_Glasses_and_a_Gun_(1970_film)",
+      "paragraphs": [
+        {
+          "context": "Just before the Bastille Day holiday weekend English secretary, Danielle 'Dany' Lang, types up a document for her advertising agency boss, Michael Caldwell, to take on a business trip to Geneva. On the way to drop off her boss and his wife, Anita, her former room-mate, at the airport, her boss gives her a envelope with her pay in it.\nAfter dropping them off Dany impulsively decides to drive to the Riviera for the weekend. When Dany pulls into a small caf\u00e9 the owner tries to return a coat to her she claims she left there the day before. At a petrol station Dany is attacked in the toilet and injures her hand. She is bemused as various strangers claim to know her. \nHeading further south she picks up a hitch-hiker, Philippe and the pair spend the night together. The following day Philippe steals Dany's car prior to reaching the coast. She later finds Philippe in Marseilles where they find a man's body and a gun in the trunk of the car. \nAfter Philippe disappears again, Dany visits the home of the dead man in Avignon and oddly finds both some of her clothes and also nude pictures of herself. Returning to the caf\u00e9 to reclaim the coat she finds a copy of her pay envelope in one of the coat's pockets. Dany is now completely perplexed by the situation and returns to the dead man's home where her boss, Michael, is waiting for her. He tells Dany that the dead man was one of Anita's lovers, whom she murdered at his home. To frame Dany, they planted evidence and set up various incidents to establish her guilt: the attack in the toilet was committed by Michael, who injured her hand so Anita could wear a bandage and be mistaken for the secretary; and the nude photos had been taken by Anita when they were room-mates. \nWhen Michael tells Dany he plans to murder her and make it look like a suicide she tells him he won't succeed as she has already sent both pay envelopes to the police.",
+          "context_id": "bf46bb4308dae60ce96a26ae4834043430a698e1",
+          "qas": [
+            {
+              "question": "What is the nickname of the person that takes her boss to the airport?",
+              "id": "96bdbf3ff8ce33e7f4dd1a078dfda1be85ac3620",
+              "answers": [
+                {
+                  "text": "Dany",
+                  "answer_start": 74
+                }
+              ]
+            },
+            {
+              "question": "What is the real first name of the person who is confused that so many people seem to know her?",
+              "id": "d076a70ba3f2396aca4d800b85b3569965d895e1",
+              "answers": [
+                {
+                  "text": "Danielle",
+                  "answer_start": 64
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who tells Dany that the dead man was a lover of Anita?",
+              "id": "a218affd230f53c2f10a6c022ffce1fb2c2b4f4f",
+              "answers": [
+                {
+                  "text": "Michael",
+                  "answer_start": 1314
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of Anita's husband? ",
+              "id": "1e5607954beefbfcdf687fc892323c42ff7bec23",
+              "answers": [
+                {
+                  "text": "Michael",
+                  "answer_start": 139
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person dropping Anita and her husband off at the airport? ",
+              "id": "79fbb728c5585fdabf0823720b3e635815c355d2",
+              "answers": [
+                {
+                  "text": "Danielle",
+                  "answer_start": 64
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who gives Danielle an envelope with her pay in it? ",
+              "id": "70724460f770b647efdd0bcde1b7dbd9e06ccdc9",
+              "answers": [
+                {
+                  "text": "Michael",
+                  "answer_start": 139
+                }
+              ]
+            },
+            {
+              "question": "What is the alias of the person who spends the night with Philippe?",
+              "id": "a6304219086b6c954c4467b2bfd96892dde9cf96",
+              "answers": [
+                {
+                  "text": "Dany",
+                  "answer_start": 74
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Exhumation and reburial of Richard III of England 3",
+      "url": "https://en.wikipedia.org/wiki/Exhumation_and_reburial_of_Richard_III_of_England",
+      "paragraphs": [
+        {
+          "context": "On 4 February 2013, the University of Leicester confirmed that the skeleton was that of Richard III. The identification was based on mitochondrial DNA evidence, soil analysis, and dental tests, and physical characteristics of the skeleton consistent with contemporary accounts of Richard's appearance. Osteoarchaeologist Jo Appleby commented: \"The skeleton has a number of unusual features: its slender build, the scoliosis, and the battle-related trauma. All of these are highly consistent with the information that we have about Richard III in life and about the circumstances of his death.\"Caroline Wilkinson, Professor of Craniofacial Identification at the University of Dundee, led the project to reconstruct the face, commissioned by the Richard III Society. On 11 February 2014, the University of Leicester announced a project headed by Turi King to sequence the entire genome of Richard III and Michael Ibsen\u2014a direct female-line descendant of Richard's sister, Anne of York\u2014whose mitochondrial DNA confirmed the identification of the excavated remains. Richard III is thus the first ancient person with known historical identity whose genome has been sequenced. A study published in Nature in December 2014 confirmed a perfect whole-mitochondrial genome match between Richard's skeleton and Michael Ibsen and a near-perfect match between Richard and his other confirmed living relative. However, Y chromosome DNA inherited via the male line found no link with five other claimed living relatives, indicating that at least one \"false-paternity event\" occurred in the generations between Richard and these men. One of these five was found to be unrelated to the other four, showing that another false-paternity event had occurred in the four generations separating them.The story of the excavation and subsequent scientific investigation was told in a Channel 4 documentary, Richard III: The King in the Car Park, broadcast on 4 February 2013. It proved a ratings hit for the channel, watched by up to 4.9 million viewers, and won a Royal Television Society award. Channel 4 subsequently screened a follow-up documentary on 27 February 2014, Richard III: The Untold Story, which detailed the scientific and archaeological analyses that led to the identification of the skeleton as Richard III.",
+          "context_id": "027fb7abb07343b3d847d44f181cfaa4c358b2b7",
+          "qas": [
+            {
+              "question": "What was the last name of the person that the Richard III Society commissioned for the reconstruction of the face?",
+              "id": "064154fdfc6ffe51d5f508aca90c9e519ac37c7f",
+              "answers": [
+                {
+                  "text": "Wilkinson",
+                  "answer_start": 602
+                }
+              ]
+            },
+            {
+              "question": "What did the Y chromosome DNA inherited via the male line that found no link with five other claimed living relatives indicate?",
+              "id": "2cc8db406f594f9e91d66670e1110e0d6d222393",
+              "answers": [
+                {
+                  "text": "at least one \"false-paternity event\" occurred",
+                  "answer_start": 1522
+                }
+              ]
+            },
+            {
+              "question": "What was the name of the documentary about the excavation on Channel 4?",
+              "id": "18a36a8c4352d2bb016eaad58906461b4f0b3fff",
+              "answers": [
+                {
+                  "text": "Richard III: The King in the Car Park",
+                  "answer_start": 1882
+                }
+              ]
+            },
+            {
+              "question": "What was the name of the follow-up documentary to Richard III: The King in the Car Park?",
+              "id": "9f345c288a46254410c69c3ab61aa355e9aee6d2",
+              "answers": [
+                {
+                  "text": "Richard III: The Untold Story",
+                  "answer_start": 2149
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Blaze of Noon",
+      "url": "https://en.wikipedia.org/wiki/Blaze_of_Noon",
+      "paragraphs": [
+        {
+          "context": "Early in the 1920s, the four McDonald brothers are performing in a carnival as a stunt flying team, when they are hired by Mercury Airlines in Newark, New Jersey, to fly the national air mail for the US Air Mail Service.\nOne of the brothers, Colin, instantly falls in love with Lucille Stewart, the nurse giving him a physical. After less than a day, he proposes and she accepts. They marry and Colin starts flying for the company along the east coast. Lucille soon becomes irritated by the brothers' extreme dedication to their work, but Colin promises that his efforts will make it possible for them to buy a home. \nWhen the youngest McDonald, Keith, crashes his aircraft and dies, Ronald feels guilty over causing his brother's death, since he was the one who taught him to fly. He quits flying and becomes a car salesman instead. When their friend and colleague \"Porkie\" (William Bendix) is fired for flying recklessly over a passenger train, he also becomes a car salesman. \nThe next brother to crash is Tad. Even though he survives, he is unable to fly again.\nColin's former girlfriend, Poppy, pays him a visit and tries to win him back, but he stays true to Lucille. Soon afterwards, their first child, a son, is born. Colin has promised to stop flying once he becomes a father, but when he is offered a raise by the company, he still continues to fly. During his first passenger flight, the wings ice over, and Colin crashes and dies. Colin's boss and Tad are the ones who have to break the news to Lucille, who is hosting their housewarming party. She decides to name her son Keith.",
+          "context_id": "308799bf64b41685aafa33b8c793fbaa144bcaa0",
+          "qas": [
+            {
+              "question": "With whom does the nurse have a child?",
+              "id": "c96bf674dc4982888cdfed82741b30a22075fb3d",
+              "answers": [
+                {
+                  "text": "Colin",
+                  "answer_start": 242
+                }
+              ]
+            },
+            {
+              "question": "Who is the last surviving McDonald brother that's able to fly?",
+              "id": "2d05753d0f092986376a8bf96c507929fcbdb207",
+              "answers": [
+                {
+                  "text": "Ronald",
+                  "answer_start": 684
+                }
+              ]
+            },
+            {
+              "question": "Which one of the brothers feel responsible for another's death?",
+              "id": "7c77434b2cd8aa975764d8f44e899801103bd627",
+              "answers": [
+                {
+                  "text": "Ronald",
+                  "answer_start": 684
+                }
+              ]
+            },
+            {
+              "question": "What are the names of the 4 brothers who were hired to fly for the U.S. Air Mail Service?",
+              "id": "b52b8ebbacd02aa50db0954a0eaf86fd147bb172",
+              "answers": [
+                {
+                  "text": "Colin",
+                  "answer_start": 242
+                },
+                {
+                  "text": "Keith",
+                  "answer_start": 646
+                },
+                {
+                  "text": "Ronald",
+                  "answer_start": 684
+                },
+                {
+                  "text": "Tad",
+                  "answer_start": 1009
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Women in Love (film)",
+      "url": "https://en.wikipedia.org/wiki/Women_in_Love_(film)",
+      "paragraphs": [
+        {
+          "context": "The film takes place in 1920, in the Midlands mining town of Beldover. Two sisters, Ursula and Gudrun Brangwen, discuss marriage on their way to the wedding of Laura Crich, daughter of the town's wealthy mine owner, Thomas Crich, to Tibby Lupton, a naval officer. At the village's church, each sister is fascinated by a particular member of the wedding party \u2013 Gudrun by Laura's brother, Gerald, and Ursula by Gerald's best friend, Rupert Birkin. Ursula is a school teacher and Rupert is a school inspector; she remembers his visit to her classroom, interrupting her botany lesson to discourse on the sexual nature of the catkin.\nThe four are later brought together at a house party at the estate of Hermione Roddice, a rich woman whose relationship with Rupert is falling apart. When Hermione devises, as entertainment for her guests, a dance in the \"style of the Russian ballet\", Rupert becomes impatient with her pretensions and tells the pianist to play some ragtime. This sets off spontaneous dancing among the whole group and angers Hermione. She leaves. When Birkin follows her into the next room, she smashes a glass paperweight against his head, and he staggers outside. He discards his clothes and wanders through the woods. Later, at the Criches' annual picnic, to which most of the town is invited, Ursula and Gudrun find a secluded spot, and Gudrun dances before some Highland cattle while Ursula sings \"I'm Forever Blowing Bubbles\". When Gerald and Rupert appear, Gerald calls Gudrun's behaviour \"impossible and ridiculous\", and then says he loves her. \"That's one way of putting it\", she replies. Ursula and Birkin wander away discussing death and love. They make love in the woods. The day ends in tragedy when Laura and Tibby drown while swimming in the lake.",
+          "context_id": "afea98cff4bfdeab984cc1e1d1ccccfdd0a45558",
+          "qas": [
+            {
+              "question": "What is the last name of the person who is fascinated by Gerald? ",
+              "id": "746c4432d38e2b462a7272262358014446afc8bb",
+              "answers": [
+                {
+                  "text": "Brangwen",
+                  "answer_start": 102
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who is fascinated by Rupert? ",
+              "id": "5e25a0ef47645d1939cf7bf531e8306367f7a439",
+              "answers": [
+                {
+                  "text": "Brangwen",
+                  "answer_start": 102
+                }
+              ]
+            },
+            {
+              "question": "What is Gerald's last name? ",
+              "id": "a0111b4cac2d11966225328b1ae07a9662066ff1",
+              "answers": [
+                {
+                  "text": "Crich",
+                  "answer_start": 166
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who remembers Rupert's visit to her classroom? ",
+              "id": "239c15c419f35f67f3cc0ecb5ff2b648cbc30311",
+              "answers": [
+                {
+                  "text": "Brangwen",
+                  "answer_start": 102
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person whose botany lesson Rupert interrupted? ",
+              "id": "ec71d6e155eff0123460ba1defb76e4982c544a1",
+              "answers": [
+                {
+                  "text": "Ursula",
+                  "answer_start": 84
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person whose relationship with Hermione is falling apart?",
+              "id": "b797261a06441d83abaff0b11a485e64711f06c4",
+              "answers": [
+                {
+                  "text": "Birkin",
+                  "answer_start": 439
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who tells the pianist to play ragtime music?",
+              "id": "31bd49ff9c5058f9e5b827ec16947d1c4cf246e3",
+              "answers": [
+                {
+                  "text": "Birkin",
+                  "answer_start": 439
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Triumph of Cleopatra",
+      "url": "https://en.wikipedia.org/wiki/The_Triumph_of_Cleopatra",
+      "paragraphs": [
+        {
+          "context": "The Triumph of Cleopatra, also known as Cleopatra's Arrival in Cilicia and The Arrival of Cleopatra in Cilicia, is an oil painting by English artist William Etty. It was first exhibited in 1821, and is now in the Lady Lever Art Gallery in Port Sunlight across the River Mersey from Liverpool. During the 1810s Etty had become widely respected among staff and students at the Royal Academy of Arts, in particular for his use of colour and ability to paint realistic flesh tones. Despite having exhibited at every Summer Exhibition since 1811 he attracted little commercial or critical interest. In 1820 he exhibited The Coral Finder, which showed nude figures on a gilded boat. This painting attracted the attention of Sir Francis Freeling, who commissioned a similar painting on a more ambitious scale.\nThe Triumph of Cleopatra illustrates a scene from Plutarch's Life of Antony and Shakespeare's Antony and Cleopatra, in which Cleopatra, Queen of Egypt, travels to Tarsus in Cilicia aboard a magnificently decorated ship to cement an alliance with the Roman general Mark Antony. An intentionally cramped and crowded composition, it shows a huge group of people in various states of undress, gathering on the bank to watch the ship's arrival. Although not universally admired in the press, the painting was an immediate success, making Etty famous almost overnight. Buoyed by its reception, Etty devoted much of the next decade to creating further history paintings containing nude figures, becoming renowned for his combination of nudity and moral messages.",
+          "context_id": "12d1244b44c80d5bda96b2576660c48546790b82",
+          "qas": [
+            {
+              "question": "What are the two other names of The Arrival of Cleopatra in Cilicia?",
+              "id": "41532a95fbbca6f86362639bf29cc76f69f11582",
+              "answers": [
+                {
+                  "text": "The Triumph of Cleopatra",
+                  "answer_start": 0
+                },
+                {
+                  "text": "Cleopatra's Arrival in Cilicia",
+                  "answer_start": 40
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person whose attention was attracted to The Coral Finder?",
+              "id": "0567f535653eab055a2eecfeccad34cf47282f00",
+              "answers": [
+                {
+                  "text": "Freeling",
+                  "answer_start": 730
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "William Etty was born in York in 1787, the son of a miller and baker. He showed artistic promise from an early age, but his family were financially insecure, and at the age of 12 he left school to become an apprentice printer in Hull. On completing his seven-year indenture he moved to London \"with a few pieces of chalk-crayons in colours\", with the aim of emulating the Old Masters and becoming a history painter. Etty gained acceptance to the Royal Academy Schools in early 1807. After a year spent studying under the renowned portrait painter Thomas Lawrence, Etty returned to the Royal Academy, drawing in the life class and copying other paintings. He was unsuccessful in all the Academy's competitions, and every painting he submitted for the Summer Exhibition was rejected.In 1811, one of his paintings, Telemachus Rescues Antiope from the Fury of the Wild Boar, was finally accepted for the Summer Exhibition. Etty was becoming widely respected at the Royal Academy for his painting, particularly his use of colour and his ability to produce realistic flesh tones, and from 1811 onwards had at least one work accepted for the Summer Exhibition each year. However, he had little commercial success and generated little interest over the next few years.\nAt the 1820 Summer Exhibition Etty exhibited The Coral Finder: Venus and her Youthful Satellites Arriving at the Isle of Paphos. Strongly inspired by Titian, The Coral Finder depicts Venus Victrix lying nude in a golden boat, surrounded by scantily-clad attendants. It was sold at exhibition to piano manufacturer Thomas Tomkinson for \u00a330 (about \u00a32,400 in 2019 terms).Sir Francis Freeling admired The Coral Finder at its exhibition, and learning that it had been sold he commissioned Etty to paint a similar picture on a more ambitious scale, for a fee of 200 guineas (about \u00a316,500 in 2019 terms). Etty had for some time been musing on the possibility of a painting of Cleopatra, and took the opportunity provided by Freeling to paint a picture of her based loosely on the composition of The Coral Finder.",
+          "context_id": "af397db2d55e18499ba00c6807b2ca515f296f18",
+          "qas": [
+            {
+              "question": "What is the first name of the person Etty painted Cleopatra for?",
+              "id": "0ab8ac9c17808646cd862f05054bb9185d6312e5",
+              "answers": [
+                {
+                  "text": "Francis",
+                  "answer_start": 1633
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "Cleopatra caused an immediate sensation; Etty later claimed that the day after the Summer Exhibition opened he \"awoke famous\". The May 1821 issue of The Gentleman's Magazine hailed Cleopatra as \"belonging to the highest class\", and Charles Robert Leslie described it as \"a splendid triumph of colour\". The painting did not meet with universal approval. Blackwood's Edinburgh Magazine conceded that the painting had been \"seen and admired at the Royal Academy\" but condemned Etty's taking a mythological approach to a historical subject:\nThe effect of this picture would have been much more intense had the painter treated it as a mere fact, and had not brought upon the scene those flying Cupids who turn the thing into a mythological fable. Real boys dressed like Cupids would have been proper, but aerial beings are impertinences, and put one out when one is thinking of the sex. If this amorous pageant had been a mere fiction, instead of having actually taken place, still the power of its delineation would have consisted in its probability.\nEtty attempted to replicate the success of Cleopatra, and his next significant exhibited work was A Sketch from One of Gray's Odes (Youth on the Prow), exhibited at the British Institution in January 1822. As with The Coral Finder and Cleopatra, this painting showed a gilded boat filled with nude figures, and its exhibition provoked condemnation from The Times:\nWe take this opportunity of advising Mr. Etty, who got some reputation for painting \"Cleopatra's Galley\", not to be seduced into a style which can gratify only the most vicious taste. Naked figures, when painted with the purity of Raphael, may be endured: but nakedness without purity is offensive and indecent, and on Mr. Etty's canvass is mere dirty flesh. Mr. Howard, whose poetical subjects sometimes require naked figures, never disgusts the eye or mind. Let Mr. Etty strive to acquire a taste equally pure: he should know, that just delicate taste and pure moral sense are synonymous terms.\nDespite the tone, Etty was pleased to be noticed by a newspaper as influential as The Times, and much later confessed how delighted he was that the \"Times noticed me. I felt my chariot wheels were on the right road to fame and honour, and I now drove on like another Jehu!\" Possibly as a result of the criticism in The Times, Freeling asked Etty to overpaint the figures in the foreground of Cleopatra. In 1829, after Etty had become a respected artist, Freeling allowed the restoration of the figures to their original condition.",
+          "context_id": "e6753492641db9428d43b5261fc2e4d1de8bf533",
+          "qas": [
+            {
+              "question": "What is the name of the person that asked the painter who was condemned by The Times to overpaint figures in Cleopatra?",
+              "id": "d0829b98ae29c573d942e2735c9fe6e1c22053bd",
+              "answers": [
+                {
+                  "text": "Freeling",
+                  "answer_start": 2334
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Lost Angel (film)",
+      "url": "https://en.wikipedia.org/wiki/Lost_Angel_(film)",
+      "paragraphs": [
+        {
+          "context": "The professors of the Institute of Child Psychology raise a foundling baby, whom they name \"Alpha\", as an experiment to see if a scientific upbringing can create a genius. By the time she is six years old, Alpha can speak Chinese, play chess and the harp, and has studied algebra and the campaigns of Napoleon, among other things.\nNewspaper reporter Mike Regan is assigned, over his protests, to write an article about her. He manages to secure an interview, despite the reluctance of the professors, and discovers that Alpha, while raised with loving care, has missed out on the joys of childhood. Disturbed by Mike's claim that magic is real, Alpha decides to investigate further and sneaks out to see Mike, leaving the confines of the institute for the first time in her life.\nShe enjoys the sights and sounds of New York as she makes her way to the offices of the newspaper. Mike is less than pleased to see her, but takes her along so he can keep a date with his girlfriend, nightclub singer Katie Mallory. Alpha takes an instant dislike to Katie; it turns out that the child has a crush on Mike. However, Katie's kindness and understanding soon win Alpha over.\nAn outbreak of measles at the Institute and the resulting quarantine force Mike to look after Alpha for a few days. That night, escaped convicted murderer Packy Roost shows up at Mike's apartment. While waiting for the reporter, he and Alpha become friends. When Mike does come back, Packy demands he find Lefty Moran, who can clear him of the crime. The reporter reluctantly agrees, eventually bringing in Lefty. It turns out that Lefty is the killer; the police take him away, and Packy is exonerated.",
+          "context_id": "167b4a9c24d81d89880ed5377e920a4e81cbd0e3",
+          "qas": [
+            {
+              "question": "What is the first name of the person that Mike is forced to write about? ",
+              "id": "4980e7217a37d4f95f614d6b999cc0b5412c2fa5",
+              "answers": [
+                {
+                  "text": "Alpha",
+                  "answer_start": 92
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person that Mike secures an interview with?",
+              "id": "188785731d459abee54fabdf00be7f121524cab6",
+              "answers": [
+                {
+                  "text": "Alpha",
+                  "answer_start": 92
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person Alpha sneaks out to see?",
+              "id": "811136a7e7a7c58ccabbcd4ed22d8962359eca65",
+              "answers": [
+                {
+                  "text": "Regan",
+                  "answer_start": 355
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person Alpha has a crush on? ",
+              "id": "864961579f651b19cde370462ffebf0b6e5980fa",
+              "answers": [
+                {
+                  "text": "Regan",
+                  "answer_start": 355
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person Alpha dislikes? ",
+              "id": "d94d21596de1e05d671267b1536f293367302b83",
+              "answers": [
+                {
+                  "text": "Mallory",
+                  "answer_start": 1003
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person that could be cleared of a crime by Mike and Lefty?",
+              "id": "0ca6dae9d0ced0f1d7e3b419489d6aeb496a9aea",
+              "answers": [
+                {
+                  "text": "Roost",
+                  "answer_start": 1328
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who is exonerated? ",
+              "id": "0ee18e5a71aa8ab6f768a80f794cba253594abfb",
+              "answers": [
+                {
+                  "text": "Roost",
+                  "answer_start": 1328
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Lake Placid 3",
+      "url": "https://en.wikipedia.org/wiki/Lake_Placid_3",
+      "paragraphs": [
+        {
+          "context": "A year after the events of the second film at Black Lake, in Aroostook County, Maine, young couple April and Jason go skinny dipping and are attacked and eaten by a group of baby crocodiles. Meanwhile, at the house of the deceased Sadie Bickerman, her nephew Nathan, his wife Susan, and their son Connor, are cleaning out the house so they can sell it. However, Sheriff Tony Willinger soon arrives and convinces Nathan and Susan not to sell. Connor chases an escaped pet lizard down to the lake where he encounters the baby crocodiles, and begins to secretly feed them.\nTwo years later, Connor has continued to feed the now adult crocodiles stolen meat from the supermarket, but he is soon caught for shoplifting by Dimitri and sent home to his babysitter, Vica, by Susan. However, Connor goes to the lake to feed the crocodiles, followed by Vica who is attacked. Vica, whose arm has been badly injured, finds Susan at Sadie's house, where they tend to Vica's arm and Connor confesses to feeding the crocodiles. Meanwhile, Nathan is searching the lake due to a number of elk disappearances. He meets four teenagers; Ellie, Tara, Aaron and Charlie who are camping on the lake. The teenagers show Nathan an elk head they previously found, leading Nathan to believe it was the act of hunter Reba, but he persuades Sheriff Tony to search the lake to make sure it is clear of crocodiles. While the teenagers camp, they decide to go swimming and the girls go into the woods and strip off their clothes and get into their bikinis. Charlie spies on them and watches them stripping their clothes and by taking pictures, but then is devoured by a crocodile.",
+          "context_id": "e564f9a1bb57aae9ec3ff9f68082bd62a57d13e1",
+          "qas": [
+            {
+              "question": "Who feeds the baby crocodiles?",
+              "id": "5ddb00e3da8bbdb4a8d66fc33c4d3997fc3c5703",
+              "answers": [
+                {
+                  "text": "Connor",
+                  "answer_start": 442
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "More Hall Annex",
+      "url": "https://en.wikipedia.org/wiki/More_Hall_Annex",
+      "paragraphs": [
+        {
+          "context": "The building housed an Argonaut class reactor with an initial output of 10 kilowatts thermal (kWt), later increased to 100 kWt in 1967. It used uranium-235 as fuel and was cooled by water. The reactor's chamber, placed on the lower floor of the facility, was 15 ft (4.6 m) high, 20 ft (6.1 m) long, and 19 ft (5.8 m) wide. During its 27-year lifespan, the reactor operated for the equivalent of 140 days, running for some days at half power and for as little as 10 minutes.The More Hall Annex was a two-story, reinforced concrete structure designed in the Brutalist style, similar to other buildings on the university campus built during the post-war era. It occupied a footprint of 69 ft 8 in (21.23 m) from north to south and 76 ft (23 m) from east to west, with a total of 7,595 square feet (705.6 m2) of interior space. The building was designed by a consortium of UW faculty members, known as The Architect Artist Group (TAAG), with input from nuclear engineering department chair Albert L. Babb. Babb requested a building that would \"show the world what nuclear power looked like\", desiring a prominent structure on the campus that would serve as a crown jewel for the department. The large glass walls enabled public viewing of the reactor room's interior, showcasing the activity inside.The first floor, partly covered by the outdoor plaza, housed the reactor, laboratory, crystal spectrometer, counting room with a nuclear densometer, classrooms, restrooms, and offices. The second floor contained the control room, an observatory, and a lecture room overlooking the reactor; it was open to the outdoor plaza on three sides, with large glass windows allowing for public observation of experiments. The reactor was placed on the lower side of the building, downhill of the plaza, to allow the ground to absorb accidental radiation leaks. The structure's roof rested on a series of perpendicular beams that also supported a three-ton (2,700 kg) crane used to lift the reactor shield between experiments.",
+          "context_id": "9bfa99894600f2c5550ceddd956d4afbcabbbb2b",
+          "qas": [
+            {
+              "question": "What was described as a building that would \"show the world what nuclear power looked like\"?",
+              "id": "40ce0c9f96d5c037524db266d6d5b7866f7c073c",
+              "answers": [
+                {
+                  "text": "The More Hall Annex",
+                  "answer_start": 473
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "T-Rex: Back to the Cretaceous",
+      "url": "https://en.wikipedia.org/wiki/T-Rex:_Back_to_the_Cretaceous",
+      "paragraphs": [
+        {
+          "context": "The plot revolves around 16-year-old Ally Hayden, the daughter of Dr. Donald Hayden, a world-famous paleontologist and museum curator. She loves dinosaurs and longs to be able to accompany him to one of the nearby paleontological digs, but her father thinks this is too dangerous and she has to settle for giving museum tours instead.\nA mysterious accident at the lab revolving an oblong fossil rock happens while Ally's father is away at a dig site with his assistant, and Ally is magically transported back in time. Among the various time periods she visits are the Late Cretaceous, when the Tyrannosaurus and Pteranodon existed.\nAlly is also transported to the early 20th Century where she meets renowned historical figures in the world of paleontology. These include dinosaur painter Charles Knight and paleontologist Barnum Brown, arguably one of the most famous paleontologists in early fossil-hunting history.\nThe shining moment of her trip to the past, however, is when Ally discovers a T. rex nest and then defends the nest from an Ornithomimus, earning the mother T. rex's respect to the point where Ally actually strokes the T. rex on its snout before the meteor is shown hitting the earth, blasting Ally back into the present day. There, she is reunited with her father.\nAt the very end, as Ally and her dad leave the museum, the fossil rock begins to shake and, with only the museum cat watching, the rock breaks apart, revealing a still living, baby Tyrannosaurus.",
+          "context_id": "b50d11fb82fa13d3bd1946baf3acbc3d2061fd19",
+          "qas": [
+            {
+              "question": "What is the first name of the character who meets Charles Knight?",
+              "id": "3c270dbb28d87f91fd23a970584423167fdf208d",
+              "answers": [
+                {
+                  "text": "Ally",
+                  "answer_start": 632
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the character who saves a nest?",
+              "id": "fa194628a5e12cae1ce1776a7575159aec65d241",
+              "answers": [
+                {
+                  "text": "Ally Hayden",
+                  "answer_start": 37
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Mr. Jones (2013 film)",
+      "url": "https://en.wikipedia.org/wiki/Mr._Jones_(2013_film)",
+      "paragraphs": [
+        {
+          "context": "Scott and Penny move out to the woods for a year to make a nature documentary. After a few weeks tensions rise as it becomes obvious that the project isn't as well thought out as they had intended. Things begin to look up when Scott's backpack is stolen and they trace the thief to a cabin not far from the one that they are staying in. This new cabin is surrounded by bizarre stick figures and other strange objects.\nThey go into the cabin and retrieve his backpack. Scott sees that there is a basement, and a sub-basement, and wants to explore more, but Penny persuades him to leave. They realize that this is the home of the almost legendary and mysterious artist, Mr. Jones.\nScott and Penny decide to make Mr. Jones the subject of their documentary. Scott flies back to New York City where he discovers that Mr. Jones is an elusive artist who has been sending his artwork to random people across the country with no rhyme or reason. He interviews several of them, all of whom seem to indicate that the weird figures have led to disturbing events in their lives. One tells him that he should stop his investigation of Mr. Jones, and if he sees him, he should just run away.",
+          "context_id": "3183a593dc4a2113c4bab55e038b08c5d66ec88e",
+          "qas": [
+            {
+              "question": "Who makes the stick figures?",
+              "id": "b264b617cb6bd21fe7f1d42a9270e88afa916272",
+              "answers": [
+                {
+                  "text": "Mr. Jones",
+                  "answer_start": 668
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Alien 51",
+      "url": "https://en.wikipedia.org/wiki/Alien_51",
+      "paragraphs": [
+        {
+          "context": "The plot revolves around a series of murders that take place over two years in the Nevada Desert near Groom Lake.\nThe movie opens with a woman being chased through the desert by an unseen creature, but then she wakes up revealing it to be a nightmare.\nTraci and her boyfriend Gibson are driving across the desert at night. Gibson keeps talking about Area 51, but Traci is only interested in reaching Las Vegas. In order to get Gibson to shut up and keep driving, Traci takes her top off and straddles his lap. Because of her distraction he runs over something, blowing out a tire. Gibson stops to change the tire, but immediately vanishes when he gets out of the car. Traci searches for him, but only finds a bloody tire iron. She runs back to the car, lights a cigarette and drives away. However, she soon has an accident and is trapped by the seatbelt. The monster picks up her cigarette outside the car and ignites the gasoline leaking from the car, setting it and Traci on fire.\nSeveral people are attacked at a small carnival, by an alien. This draws the attention of Dr. Cleo Browning.\nDr. Browning discusses killing the creature with Sheriff Sam Cash, but she is overheard by animal rights activist Roxanne, and her boyfriend Albert.  Roxanne thinks that if they capture the alien they can expose to the world what the government is doing to animals.  In the meantime, three of the carnival workers set out to capture the alien and add it to the sideshow.\nCash and Dr. Browning meet with Cletus. He speculates that the alien is living in a cave in the mountains. While the two are meeting with Cletus, Roxanne attempts to slash the sheriff's tires, sending Albert to act as a lookout. Unable to cut the tires, she looks for Albert, but is unable to find him. Eventually, when she discovers his body, she screams and starts to run, but she also killed by the alien.",
+          "context_id": "ba8c61c6c3cafd5906594360f9ccd16d737f7289",
+          "qas": [
+            {
+              "question": "What is the name of the character who gets trapped by a seatbelt?",
+              "id": "82554f4d5e1060dd056cde390488d429ef687568",
+              "answers": [
+                {
+                  "text": "Traci",
+                  "answer_start": 668
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Phantom of the Opera (1962 film)",
+      "url": "https://en.wikipedia.org/wiki/The_Phantom_of_the_Opera_(1962_film)",
+      "paragraphs": [
+        {
+          "context": "The film opens in Victorian London on a December night in 1900. The first night of the season at the London Opera House finds the opening of a new opera by Lord Ambrose D'Arcy, a wealthy and pompous man, who is annoyed and scornful when the opera manager Lattimer informs him the theatre has not been completely sold out.  No one will sit in a certain box because it is haunted. Backstage, despite the soothing efforts of the opera's producer, Harry Hunter, everyone, including the show's star, Maria, is nervous and upset as if a sinister force was at work.  The climax comes during Maria's first aria, when a side of the scenery rips apart to reveal the body of a hanged stage hand.  In a panic, the curtain is rung down, and Maria refuses to sing again.\nWith the show postponed, Harry frantically auditions new singers.  He finds a promising young star in Christine Charles, one of the chorus girls. Lord Ambrose lecherously approves of the selection, and invites Christine to dinner. In her dressing room Christine is warned against Lord Ambrose by a Phantom voice.  At dinner, Lord Ambrose attempts to seduce her, but as they are about to leave to his apartment, she is saved by Harry. On the ride back home, Christine tells Harry about the voice she heard.  Intrigued, Harry takes Christine back to the opera house, where in her dressing room, the same voice tells Harry to leave her there and go. At the same time the rat catcher is murdered by the Phantom's lackey, a dwarf. Investigating the murder, Harry leaves Christine by herself where she is approached by a man dressed in black, wearing a mask with only one eye, The Phantom of the Opera. He tells her she must come with him but she screams and The Phantom flees. Harry comforts her and takes her home.",
+          "context_id": "c80f0973e6e9e9c641d7987e283a09532e80d3fc",
+          "qas": [
+            {
+              "question": "Who warns Christine?",
+              "id": "22d118ecc212b63a4d1a7d4f578b6702e29fd813",
+              "answers": [
+                {
+                  "text": "The Phantom of the Opera",
+                  "answer_start": 1627
+                }
+              ]
+            },
+            {
+              "question": "Who is with the man who investigates the murder of the rat catcher by the lackey?",
+              "id": "76a81e765cdbcf39dd7dafe3fbcaa32ed4555f3b",
+              "answers": [
+                {
+                  "text": "Christine",
+                  "answer_start": 1522
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Silencers (film)",
+      "url": "https://en.wikipedia.org/wiki/The_Silencers_(film)",
+      "paragraphs": [
+        {
+          "context": "Once a photographer by day, spy by night, Matt Helm is now a happily retired secret agent, shooting photos of glamorous models instead of guns and enjoying a close relationship with his assistant, the lovely Lovey Kravezit. But then his old boss, Macdonald, coaxes him back to the agency ICE to thwart a new threat from the villainous organization Big O.\nThe sinister Tung-Tze is masterminding a diabolical scheme to drop a missile on an underground atomic bomb test in New Mexico and possibly instigate a nuclear war in the process. Helm's assignment is to stop him, armed with a wide assortment of useful spy gadgets, plus the assistance of the capable femme fatale, Tina, and the seemingly incapable Gail Hendricks, a beautiful but bumbling possible enemy agent.\nAlong the way, Helm is nearly sidetracked by a mysterious knife-wielding seductress and he witnesses the murder of a beautiful Big O operative, the sultry striptease artist Sarita.\nIn the end, Helm prevails, with Gail by his side as he all but singlehandedly destroys Tung-Tze's evil enterprise and plot to rule the world.",
+          "context_id": "d5d9f5bd3566697404db29ecc62ac5576d0fe89f",
+          "qas": [
+            {
+              "question": "What is the full name of the person that is armed with a wide assortment of useful spy gadgets?",
+              "id": "1b8456858c8b574a3ffc623cc6f49f9ccbdfdd75",
+              "answers": [
+                {
+                  "text": "Matt Helm",
+                  "answer_start": 42
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who prevails in his assignment? ",
+              "id": "b5c62612c01ed331dfc9112b56c38b5feee246a0",
+              "answers": [
+                {
+                  "text": "Matt",
+                  "answer_start": 42
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person by Helms side when he prevails?",
+              "id": "4622ebd1a65c27921270e988b473ae7bd47b3523",
+              "answers": [
+                {
+                  "text": "Hendricks",
+                  "answer_start": 708
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who all but singlehandedly destroys Tung-Tze?",
+              "id": "294e312ff3855b890e71471706a6fa3c5c785584",
+              "answers": [
+                {
+                  "text": "Matt",
+                  "answer_start": 42
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Trap (1966 film)",
+      "url": "https://en.wikipedia.org/wiki/The_Trap_(1966_film)",
+      "paragraphs": [
+        {
+          "context": "Fur trapper Jean La B\u00eate paddles his canoe through wild water towards the settlement in order to sell a load of furs.\nAt the settlement, a steamboat is landing and the trader and his foster-child Eve arrive at the seaport to fetch mail and consumer goods. The trader explains to Eve that the ship brings \"Jailbirds ... from the east\" and that \"their husbands-to-be had bailed them out and paid their fines and their passages with a guarantee of marriage\". Later, the captain is auctioning off one of those women because her husband-to-be has died in the meantime. Jean La B\u00eate decides to take his chance to buy the wife, but he makes his bid too late.\nTwo Canadian Indians, Yellow Dog and No Name, have told the Trader that La Bete is dead. The Trader, heavily in debt, has spent money he owes La Bete so that when La Bete calls to collect his dues, the trader has to use his own savings, to the fury of his wife.\nNext day, the trader's wife, in the need to compensate for the loss of her savings, seizes the opportunity to offer her foster-child for a thousand dollars to the simple-minded, rough-cut trapper. She praises the qualities of the shy girl and explains, that her inability to speak is caused from the shock she suffered when she had to witness how her parents were barbarously murdered several years ago.\nLa B\u00eate finally agrees to buy the mute girl and takes her against her will into the wilderness of British Columbia. Here the strange couple starts a difficult relationship characterized by mistrust and Eve's fear and dislike of the trapper. Eve vehemently rejects the advances of the gruff trapper. La B\u00eate takes her for hunting and acquaints her with the beauty and the dangers of the wilderness, but here, as well, he fails to win her trust. Eve defends herself from his advances with a knife.",
+          "context_id": "58c8cbea9393b3e4da857a2d5e03988d91125d8f",
+          "qas": [
+            {
+              "question": "Who is offered to a trader for a thousand dollars?",
+              "id": "1d9cdecab9a287fb6efdf16a6880c36c9a3f36f5",
+              "answers": [
+                {
+                  "text": "Eve",
+                  "answer_start": 196
+                }
+              ]
+            },
+            {
+              "question": "Whose qualities are praised?",
+              "id": "31c0d829cfadfe7a6b80f33d6382e9f8b1459838",
+              "answers": [
+                {
+                  "text": "Eve",
+                  "answer_start": 196
+                }
+              ]
+            },
+            {
+              "question": "Who is bought and taken into the wilderness?",
+              "id": "f69529c7c17d1fbf844c591fde6f8a6ffc0c36b2",
+              "answers": [
+                {
+                  "text": "Eve",
+                  "answer_start": 196
+                }
+              ]
+            },
+            {
+              "question": "Who is acquainted with the dangers of the wilderness by someone?",
+              "id": "5f06b43dbdb3a8400c33c5d1eda7b8e6d5f56456",
+              "answers": [
+                {
+                  "text": "Eve",
+                  "answer_start": 196
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who fails to win someone's trust?",
+              "id": "9ac3abfef889eb6001083e97c8c881e2124fa64b",
+              "answers": [
+                {
+                  "text": "La B\u00eate",
+                  "answer_start": 1318
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Maya stelae 7",
+      "url": "https://en.wikipedia.org/wiki/Maya_stelae",
+      "paragraphs": [
+        {
+          "context": "Stelae have become threatened in modern times by plundering for sale on the international art market. Many stelae are found in remote areas and their size and weight prevents them from being removed intact. Various methods are used to cut or break a stela for easier transport, including power saws, chisels, acid and heat. When a monument is well preserved, the looters attempt to cut off its face for transport. Even when successful, this results in damage to inscriptions on the sides of the stela. At worst, this method results in complete fragmentation of the stela face with any recoverable sculpture removed for sale. Traceable fragments of well known monuments have been purchased by American museums and private collectors in the past. When such monuments are removed from their original context, their historical meaning is lost. Although museums have justified their acquisition of stelae fragments with the argument that such objects are better preserved in an institution, no stela has been sold in as good a condition as it was in its original location. After 1970 there was a sharp drop in Maya stelae available on the New York art market due to the ratification of a treaty with Mexico that guarantees the return of stolen pre-Columbian sculpture that was removed from the country after the ratification date. In the early 1970s some museums, such as that of the University of Pennsylvania, responded to international criticism by no longer purchasing archaeological artefacts that lack a legally documented history, including place of origin, previous owners and an export license. Harvard University also instituted a similar policy in the early 1970s.In 1972, the initially well preserved Stela 5 at Ixkun was smashed into pieces by looters, who heated it until it shattered and then stole various pieces. A number of remaining fragments of the monument were rescued by archaeologist Ian Graham and transferred to the mayor's office in Dolores, Pet\u00e9n, where they were eventually used as construction material before once again being recovered, this time by the Atlas Arqueol\u00f3gico de Guatemala in 1989, and moved to their archaeological laboratory. At the nearby site of Ixtonton, 7.5 kilometres (4.7 mi) from Ixkun, most of the stelae were robbed before the site's existence was reported to the Guatemalan authorities. By the time archaeologists visited the site in 1985 only 2 stelae remained.In 1974, a dealer in pre-Columbian artefacts by the name of Hollinshead arranged for the illegal removal of Machaquil\u00e1 Stela 2 from the Guatemalan jungle. He and his co-conspirators were prosecuted in the United States under the National Stolen Property Act and they were the first people to be convicted under this act with reference to national patrimony laws. The act states:\n\"whoever transports, transmits, or transfers in interstate or foreign commerce any goods ... of the value of $5,000 or more, knowing the",
+          "context_id": "47f1837e4b96f5c2632ea6de69240b627066ecdd",
+          "qas": [
+            {
+              "question": "What was the name of the artefact that was smashed into pieces by looters?",
+              "id": "7ceb022c1ca72aa17b44b5d8f3057d141c317c74",
+              "answers": [
+                {
+                  "text": "Stela 5 at Ixkun",
+                  "answer_start": 1708
+                },
+                {
+                  "text": "Stela 5",
+                  "answer_start": 1708
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "5 to 7",
+      "url": "https://en.wikipedia.org/wiki/5_to_7",
+      "paragraphs": [
+        {
+          "context": "Brian Bloom, a struggling 24-year-old writer in New York City, meets a 33-year-old French woman named Arielle Pierpont. They feel powerfully attracted to one another. After their second meeting, Arielle reveals that she is married to a diplomat, Val\u00e9ry, and they have two young children. Arielle and Val\u00e9ry have an agreement that each is permitted to have extramarital affairs as long as they are limited to the time between 5 and 7 p.m. on weeknights. Brian is perplexed at this information and tells Arielle that he cannot continue the relationship with her, believing it is an unethical affair. Arielle says that, should he change his mind, she will continue to smoke on Fridays at the same place they met.\nAfter three weeks Brian decides to meet again with Arielle. She gives him a hotel key and in the evening at the hotel room they consummate their relationship. They begin to meet regularly at the same hotel room in the evenings. Val\u00e9ry, who is aware of Brian's affair with Arielle, approaches him on the street and invites Brian to his house for dinner. At dinner, Brian meets Arielle and Val\u00e9ry's children and is introduced to Val\u00e9ry's lover, a 25-year-old editor named Jane. Arielle later meets Brian's parents, Sam and Arlene. Upon learning that Arielle is a married mother of two, Sam tells Brian that he disapproves of the relationship, while Arlene accepts that they love each other despite the circumstances. When Brian is invited to a New Yorker ceremony to receive an award for one of his short stories, he is joined by Arielle, Val\u00e9ry, Jane, and his parents. Jane tells Brian that her boss Galassi, a publisher, has read his story and wants Brian to write a novel.",
+          "context_id": "34907d3302ecf08ff044099bfbe106900dafb7c4",
+          "qas": [
+            {
+              "question": "Whose wife does the writer sleep with?",
+              "id": "4c6a80be2c4f6b3749047b3a09ccce33ee75cdef",
+              "answers": [
+                {
+                  "text": "Val\u00e9ry",
+                  "answer_start": 246
+                }
+              ]
+            },
+            {
+              "question": "What's the first name of the person who is married to the man that Jane is partnered with?",
+              "id": "f647bf8a1e00a87e021095ddedb49136017a6268",
+              "answers": [
+                {
+                  "text": "Arielle",
+                  "answer_start": 195
+                }
+              ]
+            },
+            {
+              "question": "How old is Galassi's editor?",
+              "id": "cc93f91c99fb57518a1756115e97272cfbdc5773",
+              "answers": [
+                {
+                  "text": "25",
+                  "answer_start": 1155
+                }
+              ]
+            },
+            {
+              "question": "How old is the lover of the diplomat's wife?",
+              "id": "fdaf49ef82a1d4dd4a5ebc66970656c067556782",
+              "answers": [
+                {
+                  "text": "24",
+                  "answer_start": 26
+                }
+              ]
+            },
+            {
+              "question": "What does the writer's father think of his relationship with the French woman?",
+              "id": "7f217c7e6994fa0eb97116ed112a5ebcc85bce96",
+              "answers": [
+                {
+                  "text": "he disapproves",
+                  "answer_start": 1315
+                }
+              ]
+            },
+            {
+              "question": "What organization gave the writer an award?",
+              "id": "4e5abd67c4daecea3b5b20750616636fe6883f6b",
+              "answers": [
+                {
+                  "text": "New Yorker",
+                  "answer_start": 1452
+                }
+              ]
+            },
+            {
+              "question": "What is the profession of the editor's boss?",
+              "id": "a4c5487dcbd7aac1fb874c8cbaf965aa8e7f11e6",
+              "answers": [
+                {
+                  "text": "publisher",
+                  "answer_start": 1620
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Sheep 12",
+      "url": "https://en.wikipedia.org/wiki/Sheep",
+      "paragraphs": [
+        {
+          "context": "Sheep have had a strong presence in many cultures, especially in areas where they form the most common type of livestock. In the English language, to call someone a sheep or ovine may allude that they are timid and easily led. In contradiction to this image, male sheep are often used as symbols of virility and power; the logos of the Los Angeles Rams football team and the Dodge Ram pickup truck allude to males of the bighorn sheep, Ovis canadensis.\nCounting sheep is popularly said to be an aid to sleep, and some ancient systems of counting sheep persist today. Sheep also enter in colloquial sayings and idiom frequently with such phrases as \"black sheep\". To call an individual a black sheep implies that they are an odd or disreputable member of a group. This usage derives from the recessive trait that causes an occasional black lamb to be born into an entirely white flock. These black sheep were considered undesirable by shepherds, as black wool is not as commercially viable as white wool. Citizens who accept overbearing governments have been referred to by the Portmanteau neologism of sheeple. Somewhat differently, the adjective \"sheepish\" is also used to describe embarrassment.",
+          "context_id": "b04483b6ead42c8ddb2c9168f785a5d2c0e0db2a",
+          "qas": [
+            {
+              "question": "What is the name of the football team that alludes to Ovis canadensis?",
+              "id": "0827f6cece5e92018993907e5f37d9a30583a3f9",
+              "answers": [
+                {
+                  "text": "Los Angeles Rams",
+                  "answer_start": 336
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Terrible Two",
+      "url": "https://en.wikipedia.org/wiki/The_Terrible_Two",
+      "paragraphs": [
+        {
+          "context": "Leading up to the birth of their first child, Albert and Rose Poe buy a house. Seven years later, around the one year anniversary of their deaths and birthdays of both daughters, Addie and Jade, the family is mourning their loss. Albert is ready to move on, but Rose is still stuck in her grief, baking a birthday cake for the girls and speaking of them in present tense. The couple fights when Rose doesn't want to return to her job as a school teacher. \nConcerned, Albert calls Dr. Connor, whom Rose has been seeing for a few months. Rose tells Dr. Connor about the things she's been experiencing in the house, like seeing toys move and the girls talking to her, which he assures her is normal. Rose goes on to mention finding a manuscript about demons in the attic, which causes Dr. Connor to want to leave abruptly, telling her they should sell the house because he senses something bad there. Rose researches the former owner of the home, Jack Wilson, and finds newspaper archives about suspicious activity in the house.\nAlbert asks a neighbor, Scott, who has lived in the neighborhood since 1970, about their house over the years, and he declines to answer. Albert calls the realtor, Fred, and lists the house for sale. Rose tells Albert about the manuscript, which he chalks up to religious propaganda. Later, he finds a disturbing tape recording of the girls on the day they died. The girls were coaxed up on a ladder to the roof by an unseen entity. Albert came to check on them, and discovered their bodies on the ground.",
+          "context_id": "5c99db2cff61c3520b5b02804a031bd8d5596401",
+          "qas": [
+            {
+              "question": "What is the full name of the character who works as a school teacher?",
+              "id": "65f8c2a7901c38c6b9f10af3db4fe62f04199ba2",
+              "answers": [
+                {
+                  "text": "Rose Poe",
+                  "answer_start": 57
+                }
+              ]
+            },
+            {
+              "question": "Where does Dr. Connor believe that something bad is going on?",
+              "id": "c039798f468cbc48b5c6f41198fae408b9a3dcdd",
+              "answers": [
+                {
+                  "text": "the house",
+                  "answer_start": 849
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the character who finds a disturbing recording?",
+              "id": "64cc6f612ef9f8bcf510a276e01ae7a56d31463f",
+              "answers": [
+                {
+                  "text": "Albert",
+                  "answer_start": 1164
+                }
+              ]
+            },
+            {
+              "question": "What are the names of the character who were coaxed up onto the roof by an unseen entity?",
+              "id": "b07f1103642902d459abd7cf8695e5310fb8c7c3",
+              "answers": [
+                {
+                  "text": "Addie",
+                  "answer_start": 179
+                },
+                {
+                  "text": "Jade",
+                  "answer_start": 189
+                }
+              ]
+            },
+            {
+              "question": "What are the names of the characters whose bodies Albert found on the ground? ",
+              "id": "f6972bf95cf2871b9493f925b13edc73536f684d",
+              "answers": [
+                {
+                  "text": "Addie",
+                  "answer_start": 179
+                },
+                {
+                  "text": "Jade",
+                  "answer_start": 189
+                }
+              ]
+            },
+            {
+              "question": "What are the names of the characters who Rose says she hears talking to her?",
+              "id": "c1cbb5a65bba9a8af3b015d38e7231e390ed772b",
+              "answers": [
+                {
+                  "text": "Addie",
+                  "answer_start": 179
+                },
+                {
+                  "text": "Jade",
+                  "answer_start": 189
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Hell's Highway (2002 film)",
+      "url": "https://en.wikipedia.org/wiki/Hell%27s_Highway_(2002_film)",
+      "paragraphs": [
+        {
+          "context": "Out on a highway in Death Valley, a man picks up a female hitchhiker named Lucindia, and gives her a drink. Lucindia has a coughing fit upon ingesting the liquid, stumbles out of the vehicle, and is stabbed to death by the motorist. The man (revealed to be a priest, whose offer to Lucindia was holy water) buries Lucindia's body, and erects a crucifix over the impromptu grave. As the preacher prays, Lucindia reappears, and bludgeons him with his shovel as he screams, \"El Diablo!\"\nNearby, four college students (Eric, Chris, Monique, and Sarah) from Western Pennsylvania are on a road trip to Redondo Beach. Spotting Lucindia at a cluster of crosses, the quartet pick her up. When Chris mentions that a group of their friends are also on their way to Redondo, Lucindia brags that she tortured them to death before pulling out a gun and sexually assaulting Sarah. Lucindia then tries to shoot Sarah in the crotch, but is knocked out of the car by her and Eric.\nThe next day, Lucindia (who had just robbed, castrated, and murdered a motorist) catches up with the college students, who run her down, beheading and disemboweling her. On what's left of Lucindia's body, Eric finds Chris's brother's cell phone, and a battery pack that fits into a camcorder that Sarah had earlier unearthed in the desert. The group watches the last few minutes recorded by the camera, which shows Lucindia shooting all of their friends during a botched s\u00e9ance. Lucindia then turns to the camera and tells the story of a settler couple that became trapped in the valley; to try and save his wife (implied to be Lucindia), the husband killed himself so that she could consume his flesh. Her husband's body was not enough to sustain her, and in her last dying hours the woman cursed God and prayed to the Devil for salvation, and received it in exchange for a steady stream of victims.",
+          "context_id": "90c4970448b3c11eed54e9dadea09177b065ba1f",
+          "qas": [
+            {
+              "question": "Where does the female hitchhiker try to shoot the girl that was sexually assaulted?",
+              "id": "84cf8940d6a77f077e79ca0a1188a9d7fdb74bb6",
+              "answers": [
+                {
+                  "text": "in the crotch",
+                  "answer_start": 901
+                }
+              ]
+            },
+            {
+              "question": "Who finds a cell phone on the hitchhiker's body?",
+              "id": "ff71f23d9c40cf6899c891165dec9f9326a067a4",
+              "answers": [
+                {
+                  "text": "Eric",
+                  "answer_start": 1168
+                }
+              ]
+            },
+            {
+              "question": "Who does the woman named El Diablo sexually assault?",
+              "id": "18113627cc4b19d8231e082e0fec8ef008ab7ae2",
+              "answers": [
+                {
+                  "text": "Sarah",
+                  "answer_start": 859
+                }
+              ]
+            },
+            {
+              "question": "Who helps save the college student from being shot in the crotch?",
+              "id": "5ee1c7608c5f391eb857028811a93c0943af208a",
+              "answers": [
+                {
+                  "text": "Eric",
+                  "answer_start": 957
+                }
+              ]
+            },
+            {
+              "question": "Who is related to the person that owns the cell phone found on the hitchhiker's body?",
+              "id": "a05020d02d40aa812071504fcbb0568bdc9d85a8",
+              "answers": [
+                {
+                  "text": "Chris",
+                  "answer_start": 1179
+                }
+              ]
+            },
+            {
+              "question": "Who finds the cell phone on the body of the murderer?",
+              "id": "a582cc4e212ea9092bb732bd534cacdaaf17312d",
+              "answers": [
+                {
+                  "text": "Eric",
+                  "answer_start": 1168
+                }
+              ]
+            },
+            {
+              "question": "Who found the camcorders that the battery on the hitchhiker fits into?",
+              "id": "6b2f5a6b04c52f026a334c2945624abf05ad7e89",
+              "answers": [
+                {
+                  "text": "Sarah",
+                  "answer_start": 1260
+                }
+              ]
+            },
+            {
+              "question": "Who did the wife of the man who sacrificed himself for her reach out to for salvation?",
+              "id": "80d0b6ef17c65ed0de2d5874fe92b42eaa5e01b7",
+              "answers": [
+                {
+                  "text": "the Devil",
+                  "answer_start": 1779
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Keswick, Cumbria",
+      "url": "https://en.wikipedia.org/wiki/Keswick,_Cumbria",
+      "paragraphs": [
+        {
+          "context": "With the Dissolution of the Monasteries, between 1536 and 1541, Furness and Fountains Abbeys were supplanted by new secular landlords for the farmers of Keswick and its neighbourhood. The buying and selling of sheep and wool were no longer centred on the great Abbeys, being handled locally by the new landowners and tenants. This enhanced Keswick's importance as a market centre, though at first the town remained only modestly prosperous: in the 1530s John Leland wrote of it as \"a lytle poore market town\". By the second half of the century copper mining had made Keswick richer: in 1586 William Camden wrote of \"these copper works not only being sufficient for all England, but great quantities of the copper exported every year\" with, at the centre, \"Keswicke, a small market town, many years famous for the copper works as appears from a charter of king Edward IV, and at present inhabited by miners\".Earlier copper mining had been small in scale, but Elizabeth I, concerned for the defence of her kingdom, required large quantities of copper for the manufacture of weapons and the strengthening of warships. There was the additional advantage for her that the Crown was entitled to royalties on metals extracted from English land. The experts in copper mining were German, and Elizabeth secured the services of Daniel Hechstetter of Augsburg, to whom she granted a licence to \"search, dig, try, roast and melt all manner of mines and ores of gold, silver, copper and quicksilver\" in the Keswick area and elsewhere.\nAs well as copper, a new substance was found, extracted and exploited: this was variously called wad, black lead, plumbago or black cauke, and is now known as graphite. Many uses were quickly discovered for the mineral: it reduced friction in machinery, made a heat-resistant glaze for crucibles, and when used to line moulds for cannonballs, resulted in rounder, smoother balls that could be fired further by English naval cannon. Later, from the second half of the 18th century, it was used to make pencils, for which Keswick became famous.The copper mines prospered for about seventy years, but by the early 17th century the industry was in decline. Demand for copper fell and the cost of extracting it was high. Graphite mining continued, and quarrying for slate began to grow in importance. Other small-scale industries grew up, such as tannery and weaving. Although the boom of the mid-16th century had finished, the town's economy did not slide into ruin, and the population remained generally constant at a little under 1,000.",
+          "context_id": "4abc53c1ec8149c2580a482942372040474bf487",
+          "qas": [
+            {
+              "question": "What is the current name of the mineral for which many uses were quickly discovered? ",
+              "id": "e60f5b0c195412b6b59507e3d95bb6b4baa29c70",
+              "answers": [
+                {
+                  "text": "graphite",
+                  "answer_start": 1681
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "Keswick lies in north-western England, in the heart of the northern Lake District. The town is 31.4 miles (50.5 km) south-west of Carlisle, 22.1 miles (35.6 km) northwest of Windermere and 14.2 miles (22.9 km) south-east of Cockermouth. Derwentwater, the lake to the south-west of the town, is approximately 3 miles (4.8 km) long by 1 mile (1.6 km) wide and is some 72 feet (22 m) deep. It contains several islands, including Derwent Isle, Lord's Island, Rampsholme Island and St Herbert's Island, the largest. Derwent Isle is the only island on the lake that is inhabited; it is run by the National Trust and open to visitors five days a year. The land between Keswick and the lake consists mainly of fields and areas of woodland, including Isthmus Wood, Cockshot Wood, Castlehead Wood and Horseclose and Great Wood, further to the south. The River Derwent flows from Derwentwater to Bassenthwaite, the most northerly of the major Cumbrian lakes. The Derwent and its tributary the Greta, which flows through Keswick, meet to the east of Portinscale. The source of the Greta is near Threlkeld, at the confluence of the River Glenderamackin and St John's Beck.Keswick is in the lee of the Skiddaw group, the oldest group of rocks in the Lake District. These fells were formed during the Ordovician period, 488 to 443 million years ago; they form a triangle sheltering the town, reaching a maximum height of 931m on Skiddaw itself. To the west of Portinscale, to the south-west of the village of Thornthwaite, is Whinlatter Forest Park and Grisedale Pike. To the east, beyond Castlerigg stone circle, is St John's in the Vale, at the foot of the Helvellyn range, which is popular with ramblers starting from Keswick. In 2010, Electricity North West, United Utilities, the Lake District National Park Authority and the conservation charity Friends of the Lake District invested \u00a3100,000 to remove power lines and replace them with underground cables, to improve the quality of scenery in the vicinity.Climatically, Keswick is in the North West sector of the UK, which is characterised by cool summers, mild winters, and high monthly rainfalls throughout the year. The wettest months fall at the end of the year, the peak average of 189.3 mm falling in October. Rain, sunshine and temperature figures are shown below.",
+          "context_id": "64f27e1516667e4ce7726c5c75f44a6b3eeaa790",
+          "qas": [
+            {
+              "question": "What is the name of the oldest group of rocks in the Lake District?",
+              "id": "6e75e8839e5070b00a237774b07d1687fe732a6c",
+              "answers": [
+                {
+                  "text": "Skiddaw group",
+                  "answer_start": 1188
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "Keswick is the home of the Theatre by the Lake, opened in 1999. The theatre serves a dual purpose as the permanent home of a professional repertory company and a venue for visiting performers and festivals. It replaced the Century Theatre or \"Blue Box\", which had spent 25 years in semi-retirement on a permanent lakeside site in Keswick, after a career of similar length as a mobile theatre. The Alhambra cinema in St John Street, opened in 1913, is one of the oldest continuously functioning cinemas in the country; it is equipped with digital technology and satellite receiving equipment to allow the live screening of plays, operas and ballet from the National Theatre, Royal Opera House and other venues.The town is the site of the Cumberland Pencil Museum. One of the exhibits is what is claimed to be the world's largest coloured pencil. Fitz Park, on the bank of the River Greta, is home to the Keswick Museum and Art Gallery, a Victorian museum which features the Musical Stones of Skiddaw, Southey manuscripts, and a collection of sculptures and paintings of regional and wider importance, including works by Epstein, John Opie, Richard Westall and others. After extensive restoration and enlargement the museum reopened in 2014. In 2001 the cricket ground in Fitz Park was named the most beautiful in England by Wisden Cricket Monthly.Greta Hall (see Lake Poets, below), is a Grade I listed building. The home of Coleridge in 1800\u201304 and Southey from 1803 until 1843, it later became part of Keswick School and is now in private ownership, partly divided into holiday flats. The three-storey house dates to the late 18th century and features a flush-panelled central double door with Gothic top panels and Venetian windows. A carved oak fireplace inside is dated to 1684. The Moot Hall is a prominent Grade II* listed building situated at the southern end of Main Street. It was built in 1571 and rebuilt in 1695, and the current building dates to 1813. It is built of lime-washed stone and slate walling, and has a square tower on the north end with a round-arched doorway and a double flight of exterior steps. At the top of the tower is what the Keswick Tourist Information Board describes as an \"unusual one-handed clock\". Formerly an assembly building, The Moot Hall contains a tourist information centre on the ground floor, with an art gallery on the floor above.The prominent social thinker and art critic John Ruskin, who had many associations with Keswick, once said that the town was a place almost too beautiful to live in. In October 1900, mainly through the efforts of Rawnsley, a simple memorial of Borrowdale slate was erected to Ruskin at Friars Crag. The monument is a now a Grade II listed structure.",
+          "context_id": "410197c087dde9e5592298764b84a3876605f627",
+          "qas": [
+            {
+              "question": "What is the name of the Grade II* listed building that was originally built in 1571 and rebuilt in 1695?",
+              "id": "8332b479279a087400286c3881f569af46744bef",
+              "answers": [
+                {
+                  "text": "The Moot Hall",
+                  "answer_start": 1783
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "All Neat in Black Stockings",
+      "url": "https://en.wikipedia.org/wiki/All_Neat_in_Black_Stockings",
+      "paragraphs": [
+        {
+          "context": "Ginger is a window washer with an eye for the girls.  His best friend and neighbor, Dwyer, (Jack Shephard) swaps girls with him.  Ginger is washing hospital windows and he sets up a date with nurse Babette.  A patient gives Ginger keys to his house and asks him to care for his pets during his hospital stay.  Ginger takes Babette to the local pub but his interest wanders to Carole and Jill.  He sets up a date with Carole and later that night he switches date Babette with Dwyer.  Best friends share everything.\nGinger cares for Mr. McLaughlin's birds, rabbits, white rats and many aquariums.  This home is far nicer than Ginger's run down apartment.  In fact his pushy brother-in-law moves in with Ginger's pregnant sister, Cecily.  Issur even moves in his girlfriend, Jocasta.  Milquetoast sister seems not to object.\nGinger takes Carole iceskating but his interest moves to her friend, Jill.  He starts dating Jill and even buys her a large plush Penquin.  He meets Jill's mother and Dwyer sees a difference in his friend.  Ginger does not even try to have sex with Jill.  Jill and her mother live together and Ginger befriends Mom.\nIssur decides to have large unauthorized party in the borrowed residence.  Angry Ginger shows up and starts to kick people out.  The house was trashed.  Later that night, Ginger finds Jill in bed with Dwyer.  Jill has lost her virginity and Dwyer thought nothing was wrong because they always slept with each other's women.  Brother-in-law goes off to Mexico with Jocasta.  Jill ends up pregnant to Dwyer.",
+          "context_id": "b953bd7b641c115ff804cb361a3fc78e3ecfb3a7",
+          "qas": [
+            {
+              "question": "What animal is the stuffed animal the window washer buys?",
+              "id": "d83c201618212727f8a3519fbfa7e93d8ebb9d21",
+              "answers": [
+                {
+                  "text": "Penquin",
+                  "answer_start": 952
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Forgotten Girls",
+      "url": "https://en.wikipedia.org/wiki/Forgotten_Girls",
+      "paragraphs": [
+        {
+          "context": "Factory worker Judy Wingate financially supports her stepmother Frances, who is keeping company with Eddie Nolan, a gangster. Eddie makes a pass at Judy, who knocks him cold with a skillet. A furious Frances finds Eddie recovering, strikes him again and kills him. But it is Judy who is arrested, convicted and sent to prison for five years.\nA reporter covering the trial, Dan Donahue, develops a romantic attraction to Judy, who finds prison bearable, at least being far from her wicked stepmother. A guilty conscience persuades Frances, however, to offer $10,000 from Judy's life insurance policy to mobsters Gorno and Mullins to break her out of jail.\nAll spirals downhill from there. Judy threatens to go to the police and tell all she knows. Mullins, angry with Frances, runs her down with a car. On her deathbed, Frances attempts to confess, but Gorno shoots her before she can speak. Donahue and the police, however, are able to get the better of the villains and clear Judy's name once and for all.",
+          "context_id": "4555f7a512bf2bb7d9cfe821308d21aff5fd4974",
+          "qas": [
+            {
+              "question": "What is the name of the person that should go to prison for killing Eddie?",
+              "id": "2c47438eb2e5d69bdbb5b8034d8f4e3ea49a861f",
+              "answers": [
+                {
+                  "text": "Frances",
+                  "answer_start": 64
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Dunwich Horror (film)",
+      "url": "https://en.wikipedia.org/wiki/The_Dunwich_Horror_(film)",
+      "paragraphs": [
+        {
+          "context": "A woman groans and writhes with the pain of childbirth in a bedroom from a bygone era as two elderly women - who appear to be twins - and an elderly man watch. She is then led out of the room by the elderly man.\nAt the Miskatonic University in Arkham, Massachusetts, Dr. Henry Armitage has just finished a lecture on the local history and the very rare and priceless book known as the Necronomicon. He gives the book to his student Nancy Wagner to return to the library. She is followed by a stranger, who later introduces himself as Wilbur Whateley. Wilbur asks to see the book, and though it is closing time and the book is reputedly the only copy in existence, Nancy allows it under the influence of his hypnotic gaze.\nWilbur's perusal of the book is cut short by Henry, who has researched Wilbur's family's sordid past. His warnings about the Whateley's go unheeded by Nancy, who decides to give Wilbur a ride back to Dunwich after he misses his bus, perhaps purposely. At a gas station on the outskirts of town, Nancy first encounters the ill-esteem in which the locals hold Wilbur.\nOnce back at the Whateley house, she meets Old Whateley, Wilbur's grandfather. Her car is then disabled and she is drugged by Wilbur. She decides under the influence of hypnosis and drugs to spend the weekend, and does not change her mind when Henry and Nancy's classmate Elizabeth arrive from Arkham the next morning. The duo does not abandon Nancy, however. They investigate further and discover that Wilbur's mother, Lavinia, is still alive and in an asylum. The town doctor, Dr. Cory informs Henry that Lavinia delivered twins when Wilbur was born, but one was stillborn, though he was not there for the delivery and never saw the body. The childbirth was very traumatic and Lavinia \"lost her mind\" during it, and nearly died.",
+          "context_id": "f8b526a9f15b381fdd10ecd7e99092453848b8d5",
+          "qas": [
+            {
+              "question": "What is the name of the person that gave birth to twins?",
+              "id": "7e42d75dbc4a2a155f619854d82912c1e1d181a2",
+              "answers": [
+                {
+                  "text": "Lavinia",
+                  "answer_start": 1508
+                }
+              ]
+            },
+            {
+              "question": "Who drugs Nancy Wagner?",
+              "id": "7af7224f3c8eb4b42cbc4fb46be5bb2292396868",
+              "answers": [
+                {
+                  "text": "Wilbur Whateley",
+                  "answer_start": 534
+                }
+              ]
+            },
+            {
+              "question": "Besides Henry, who else checks on Nancy the next morning?",
+              "id": "96ef7837705d1fae943733a30a68d2b1870c597d",
+              "answers": [
+                {
+                  "text": "Elizabeth",
+                  "answer_start": 1360
+                }
+              ]
+            },
+            {
+              "question": "Which person is in an asylum?",
+              "id": "349060891306c032fc064c114ad0b9860ca38a42",
+              "answers": [
+                {
+                  "text": "Lavinia",
+                  "answer_start": 1508
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Assassination of Spencer Perceval 1",
+      "url": "https://en.wikipedia.org/wiki/Assassination_of_Spencer_Perceval",
+      "paragraphs": [
+        {
+          "context": "Bellingham was born in about 1770, in the county of Huntingdonshire. His father, also named John, was a land agent and painted miniatures. His mother Elizabeth was from a well-to-do Huntingdonshire family. In 1779 John senior became mentally ill, and, after confinement in an asylum, died in 1780 or 1781. The family  were then provided for by William Daw, Elizabeth's brother-in-law, a prosperous lawyer who arranged Bellingham's appointment as an officer cadet on board the East India Company's ship Hartwell. En route to India the  ship mutinied and was wrecked of the coast of the Cape Verde islands; Bellingham survived and returned home.  Daw then helped him to set up in business as a tin plate manufacturer in London, but after a few years the business failed, and Bellingham was made bankrupt in 1794. He appears to have escaped debtors' prison, perhaps through the further intervention of Daw. Chastened by this experience, he decided to settle down, and obtained a post as a book-keeper with a firm engaged in trade with Russia. He worked hard, and was sufficiently regarded by his employers to be appointed in 1800 as the firm's resident representative in Archangel, Russia. On his return home, Bellingham set up his own trading business, and moved to Liverpool. In 1803 he married Mary Neville from Dublin.",
+          "context_id": "d3d6a65e43c923638d1a324e5822f3898eac3903",
+          "qas": [
+            {
+              "question": "What is the full name of the person whose wife is from Dublin?",
+              "id": "427f0a04ab4917e9e60652dec7d761204b0d8764",
+              "answers": [
+                {
+                  "text": "Bellingham",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Capon Chapel",
+      "url": "https://en.wikipedia.org/wiki/Capon_Chapel",
+      "paragraphs": [
+        {
+          "context": "Capon Chapel (  KAY-p\u0259n), also historically known as Capon Baptist Chapel and Capon Chapel Church, is a mid-19th century United Methodist church located near to the town of Capon Bridge, West Virginia in the United States. Capon Chapel is one of the oldest existing log churches in Hampshire County, along with Mount Bethel Church and Old Pine Church.\nA Baptist congregation was gathering at the site of the present-day church by at least 1756. Primitive Baptist minister John Monroe (1750\u20131824) is credited for establishing a place of worship at this site; he is interred in the church's cemetery. The land on which Capon Chapel was built originally belonged to William C. Nixon (1789\u20131869), a member of the Virginia House of Delegates; later, it was transferred to the Pugh family. The first documented mention of a church at the Capon Chapel site was in March 1852, when Joseph Pugh allocated the land to three trustees for the construction of a church and cemetery.\nDuring the early years of Capon Chapel, no Protestant denomination was the exclusive owner or occupant, and the church was probably utilized as a \"union church\" for worship by any Christian denomination. Capon Chapel was used as a place of worship by Baptists until the late 19th or early 20th century. In the 1890s, Capon Chapel was added as a place of worship on the Capon Bridge Methodist circuit of the Southern Methodist Episcopal Church. As of 2017, Capon Chapel remains a Methodist church, now a part of the United Methodist Church, holding Methodist services four Sundays per month at 1pm. Open table communion is held on the first Sunday of each month. Capon Chapel also maintains a daily devotion hotline.",
+          "context_id": "2f41feb9054d9e34f7e4eae4ff4769deec1c7709",
+          "qas": [
+            {
+              "question": "What is the last name of the person who is interred in the church's cemetery?",
+              "id": "b3df1c03d2084b713a1276a6baac03b0eff52728",
+              "answers": [
+                {
+                  "text": "Monroe",
+                  "answer_start": 477
+                }
+              ]
+            },
+            {
+              "question": "The land of what was later transferred to the Pugh family?",
+              "id": "a7f0b5aeb96a8bd275c6a2a8b74d24d871228c65",
+              "answers": [
+                {
+                  "text": "Capon Chapel",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "The cemetery is less than an acre in size and is located to the immediate east of the church, surrounded by a wrought iron fence manufactured by Stewart Iron Works. As of 2012, the cemetery contains approximately 270 interments, including John Monroe (1750\u20131824), Virginia House of Delegates member William C. Nixon (1789\u20131869), West Virginia House of Delegates member Captain David Pugh (1806\u20131899), American Civil War veterans from the Union and the Confederacy, and free and enslaved African Americans. Gertrude Ward (1896\u20131988), a local historian and orchardist, is also interred in the cemetery. Captain David Pugh was an elected representative Hampshire County, who voted to secede from the Union in 1861.Older gravestones in the cemetery are generally cut from limestone, and the gravestones placed after 1900 are predominantly made of polished granite. Most of the gravestones have weathered significantly. The gravestones are generally rounded or rectangular in shape, and are placed on small stone foundations. The gravestones of prominent local leaders are more ornate in character, including that of Captain David Pugh and his family, who are buried under a large obelisk that lists the names of his three wives and their respective children. Nixon's gravestone is deteriorating due to advanced weathering; it is made of limestone and contains a carving of an open book. Following the purchase of a rectangular land tract around 1990, the cemetery was expanded on the east side. This section of the cemetery is excluded from the church's historically-recognized boundaries, as it was not associated with the church during the period of its greatest significance.The cemetery perimeter is lined on three sides by a cast wrought iron fence, accessible by a gate 3 feet (0.91 m) in width at its western entryway. The wrought iron fence is 4 feet (1.2 m) in height, and has approximately 1-inch (2.5 cm) diameter tubular fence posts, which are supported by three horizontal metal rails. The fence posts are capped with white-painted stylized arrows, with a ball at the tip. A shield with the emblem reading, \"The Stewart Iron Works, Cincinnati, Ohio\", is emblazoned on the fence's gate. The cemetery's eastern extension is surrounded by chain-link fencing.",
+          "context_id": "489b651a73aeaac91e1e9920c176b8e464a4ca92",
+          "qas": [
+            {
+              "question": "What is the full name of the person whose gravestone is deteriorating due to advanced weathering? ",
+              "id": "fd94606c6e33c5a4ddf5329f1ad3453dabf3040c",
+              "answers": [
+                {
+                  "text": "William C. Nixon",
+                  "answer_start": 299
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person who voted to secede from the Union in 1861?",
+              "id": "1a7f12e4341153fcc4ab8044e219fa357dec3afe",
+              "answers": [
+                {
+                  "text": "David Pugh",
+                  "answer_start": 609
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Fair Game (1995 film)",
+      "url": "https://en.wikipedia.org/wiki/Fair_Game_(1995_film)",
+      "paragraphs": [
+        {
+          "context": "Kathryn \"Kate\" McQuean is a Miami lawyer who, in the course of a divorce proceeding, attempts to seize a 157-foot freighter docked off the Florida coast in lieu of unpaid alimony.\nThe freighter, which is owned by criminal Emilio Juantorena, is the current base of operations of Ilya Pavel Kazak, a former KGB agent who has become an international money laundering expert, and has also become the leader of a group of rogue KGB members, including Stefan, Leonide \"Hacker\" Volkov, Navigator, Rosa and Zhukov.\nWhen Kate is unintentionally hit by a stray bullet, Miami detective Max Kirkpatrick is assigned to the case. Then an attempt is made on Kate's life by Kazak, who \u2014 after killing Juantorena \u2014 assembles his team into tracking and killing Kate; Max then becomes her protector.\nKate, Max, and two of his colleagues stay at a hotel. They order pizza, but Volkov traces the order, and Rosa and two henchmen infiltrate the hotel and kill Max's colleagues. Max manages to kill the whole hit squad and he and Kate then leave. After Max contacts his superior, Lt. Meyerson, FBI agents are sent to escort them. The \"agents\" turn out to be henchmen working for Kazak, and Max's partner and long-time friend Detective Louis Aragon is killed in the process. After killing some of Kazak's men, Max and Kate travel throughout Florida, trying to avoid Kazak and find out why he wants Kate dead.",
+          "context_id": "6d6e388976424eab0285fd489583567930eb2776",
+          "qas": [
+            {
+              "question": "What is the full name of the person who kills the owner of the freighter?",
+              "id": "f57cb48cb07c74f17eab75b3dc9da13f3dbabd3d",
+              "answers": [
+                {
+                  "text": "Ilya Pavel Kazak",
+                  "answer_start": 278
+                }
+              ]
+            },
+            {
+              "question": "What is the alias of the person who traces the pizza order?",
+              "id": "dd650c7091da17101802f1a8caec4039911d6990",
+              "answers": [
+                {
+                  "text": "Hacker",
+                  "answer_start": 463
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person that want to find out why Ilya Pavel Kazak wants Kathryn \"Kate\" McQuean dead?",
+              "id": "3b86b368f3891a154b573b445b70cb1ecc4dab70",
+              "answers": [
+                {
+                  "text": "Max Kirkpatrick",
+                  "answer_start": 575
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Black Moshannon State Park",
+      "url": "https://en.wikipedia.org/wiki/Black_Moshannon_State_Park",
+      "paragraphs": [
+        {
+          "context": "Black Moshannon State Park is a 3,481-acre (1,409 ha) Pennsylvania state park in Rush Township, Centre County, Pennsylvania, United States. It surrounds Black Moshannon Lake, formed by a dam on Black Moshannon Creek, which has given its name to the lake and park. The park is just west of the Allegheny Front, 9 miles (14 km) east of Philipsburg on Pennsylvania Route 504, and is largely surrounded by Moshannon State Forest. A bog in the park provides a habitat for diverse wildlife not common in other areas of the state, such as carnivorous plants, orchids, and species normally found farther north. As home to the \"[l]argest reconstituted bog/wetland complex in Pennsylvania\".Humans have long used the Black Moshannon area for recreational, industrial, and subsistence purposes. The Seneca tribe used it as hunting and fishing grounds.  European settlers cleared some land for farming, then clear-cut the vast stands of old-growth White Pine and Eastern Hemlock to meet the needs of a growing nation during the late 19th century. Black Moshannon State Park rose from the ashes of a depleted forest that was largely destroyed by wildfire in the years following the lumber era. The forests were rehabilitated by the Civilian Conservation Corps during the Great Depression of the 1930s. Many of the buildings built by the Civilian Conservation Corps stand in the park today and are protected on the list of National Register of Historic Places in three historic districts.\nBlack Moshannon State Park is open year-round for recreation and has an extensive network of trails which allow hiking, biking, and viewing the bog habitat at the Black Moshannon State Natural Area. The park is in Pennsylvania Important Bird Area #33, where bird watchers have recorded 175 different species. It is also home to many rare and unusual plants and animals, due to its location atop the Allegheny Plateau; the lake is at an elevation of about 1,900 feet (580 m). Much of the park is open for hunting and the lake and creek are open for fishing, boating, and swimming. In winter it is a popular destination for cross-country skiing, and was home to a small downhill skiing area from 1965 to 1982. Picnics and camping are also popular, and the \"Friends of Black Moshannon State Park\" group promotes the park and all of the recreational activities associated with it.",
+          "context_id": "e168a4a01caaae050faea983425d218e75bd2a12",
+          "qas": [
+            {
+              "question": "What is the name of the group that promotes the 3,481-acre park and all of the recreational activities?",
+              "id": "61e5d2fa885b3ed17afab8ecf49fd61d20a7fbe2",
+              "answers": [
+                {
+                  "text": "Friends of Black Moshannon State Park",
+                  "answer_start": 2229
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the group that built many of the buildings that stand in park that is just west of the Allegheny Front?",
+              "id": "56ca5945426d3526cb6c72fc842c84cab94cdfd5",
+              "answers": [
+                {
+                  "text": "Civilian Conservation Corps",
+                  "answer_start": 1323
+                }
+              ]
+            },
+            {
+              "question": "In what decade were the forests of the park that is east of Philipsburg rehabilitated?",
+              "id": "16c2dfb82ea01fcb8193212e4b84459d1ce0d983",
+              "answers": [
+                {
+                  "text": "1930s",
+                  "answer_start": 1281
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "It's a Free World...",
+      "url": "https://en.wikipedia.org/wiki/It%27s_a_Free_World...",
+      "paragraphs": [
+        {
+          "context": "Angie, a young woman frustrated after being fired from her thirtieth dead-end job, decides to set up a recruitment agency of her own, running it from her kitchen with her friend and flatmate Rose.  Angie is able to build a successful business, while also dealing with a neglected son who gets in trouble at school and parents who disapprove of her venture. She also has to keep reassuring Rose that they will become legitimate once the business is on a firm financial footing - they do not have a licence, but Angie at least insists on only hiring workers with papers, not illegal immigrants.\nMeanwhile, Angie becomes romantically involved with Karol, an English-speaking Pole who is in the same predicament as those Angie recruits. She also helps Mahmoud, his wife and two young daughters, much to Rose's distress. Mahmoud has been ordered deported, but he has gone into hiding to avoid a likely jail sentence back home in Iran.\nDespite Rose's misgivings, Angie becomes increasingly eager to do whatever it takes to build the business. When Angie anonymously informs the government about a camp of immigrants, that is the final straw for Rose. She quits.\nDisaster strikes when one employer refuses to pay twenty of Angie's workers the \u00a340,000 they are owed. They blame her, and some of them take drastic action. They first kidnap her son Jamie, then tie her up. After searching her flat, they take her profits (about a quarter of what they are due) and leave, but not before warning her that they want the rest or she will never see her son again. Soon after, Jamie shows up, unaware that the \"policemen\" he was talking to were fake. In the final scene, Angie abandons her scruples completely; she travels to the Ukraine to knowingly recruit illegal workers, offering to obtain forged papers for them.",
+          "context_id": "2b61074be2d1c90c3204c1d30cff78bc275fc332",
+          "qas": [
+            {
+              "question": "What's Rose's flatmate's son's name?",
+              "id": "777b24d60d872799a5f6ba8afec6d463aeaa5333",
+              "answers": [
+                {
+                  "text": "Jamie",
+                  "answer_start": 1339
+                }
+              ]
+            },
+            {
+              "question": "Where will the Iranian man Angie helps probably end up if he's deported?",
+              "id": "70fee67ce7b4614931ff5da27eea889a33b03f76",
+              "answers": [
+                {
+                  "text": "jail",
+                  "answer_start": 897
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Maximum Risk",
+      "url": "https://en.wikipedia.org/wiki/Maximum_Risk",
+      "paragraphs": [
+        {
+          "context": "Alain Moreau is a cop in Nice, France. Alain is at a funeral that is being held for a fellow cop, when Alain's partner Sebastien shows up, and requests for his presence at a crime scene. When they arrive, Sebastien shows Alain a dead body of someone that looks exactly like him. They discover that his name was Mikhail Suvorov, who was born on exactly the same day Alain was. As it turns out, Mikhail is the twin brother Alain never knew he had.\nTracing his brother's steps back to New York City, Alain discovers that Mikhail was a member of the Russian Mafia, who was chased down and killed when he attempted to get out.  Of course, now Alain is mistaken for Mikhail, who was also mixed up in a series of affairs concerning the FBI and the Russian mafia. With his only real ally being Mikhail's fianc\u00e9 Alex Bartlett, Alain sets out to avenge his brother's death, which is complicated not only by the Mafia, but by two corrupt FBI agents.",
+          "context_id": "dacfe4e849cf674697438f6e52b6c5ebea1b0507",
+          "qas": [
+            {
+              "question": "What is the last name of the person whose presence was needed at a crime scene? ",
+              "id": "865814eb28ce1810d455ebe387939d3c8cc633b2",
+              "answers": [
+                {
+                  "text": "Moreau",
+                  "answer_start": 6
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person who looks like the victim at the crime scene?",
+              "id": "fcfaad030ae1207c44f5e4f13c1e8b4fca0f8965",
+              "answers": [
+                {
+                  "text": "Alain Moreau",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Endings (film)",
+      "url": "https://en.wikipedia.org/wiki/Endings_(film)",
+      "paragraphs": [
+        {
+          "context": "A strung-out drug addict, Chris Ryan, holds his knife to a little girl's throat while the other patrons look on in horror.\nEmmy Ferguson, a ten-year-old at home with her father, Charlie, who is medicating her for leukemia.  She overhears a doctor telling him that  she probably won't live to see another day.  Charlie clearly loves her and protects her as if it's his only purpose in life, and he goes into a panic a little later when he finds Emmy missing from her room. \nAdonna Frost, trying to get her family ready for the day.  As they finally leave, she faints dead away.\nAdonna's doctor explains that her cancer is now advanced and that she should have been getting treatment.\nAfter Chris steals from his mother to get drug money \u2013 and allows his friend to assault her \u2013 he is kidnapped by a group calling themselves the Death Prevention Squad. Chris, Adonna, and Emmy make another stop - for him to get drugs (only after Emmy coaxes Adonna to agree).  Chris has to convince the dealer that he is for real, and he references Jamie, who told him about this dealer.  The drug dealer provides him with what he wants and mentions that Jamie is coming over later.  Chris is heartbroken and tries to buy off the dealer to get him not to sell drugs to Jamie  Back in the car, Emmy wants to know how to take the drugs, so Chris (to Adonna's chagrin) demonstrates.\nThe police find Charlie at his ex-wife's place.  They take him away for questioning and interview her.  She tells them she was just Emmy's stepmom and that Emmy's real mom left the family years ago.\nAfter stopping by a roadside carnival and a bridge at night, the three travelers make their way to their destination - which turns out to be a cemetery.  Emmy's mom is dead and she wanted to visit her grave.\nThe sun has risen, and Chris and Adonna must decide what to do.  Chris tells her he will call the police and stay with Emmy's body to explain.  He tells her to go home to her family.",
+          "context_id": "b8299a503f13e7c8aff3f38d7d7ae1d38121fee4",
+          "qas": [
+            {
+              "question": "What is the first name of the person who is told that their daughter won't live to see another day?",
+              "id": "f5a695209c17d8d3b7feddb0eec6cd2c40cd0dd2",
+              "answers": [
+                {
+                  "text": "Charlie",
+                  "answer_start": 178
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who gets what they want from a drug dealer?",
+              "id": "2816e30673b4e20c7868cd2374088ffea8d1488c",
+              "answers": [
+                {
+                  "text": "Chris",
+                  "answer_start": 959
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who is taken away for questioning?",
+              "id": "8af4fe98e8aa62b81a2aecdf0ac45e6b38ab6ef7",
+              "answers": [
+                {
+                  "text": "Charlie",
+                  "answer_start": 1378
+                }
+              ]
+            },
+            {
+              "question": "What are the first names of the three travelers who make their way to their final destination, which is a cemetery?",
+              "id": "a2a5011c6b93f70aa37a0102b88cc7566bbc820e",
+              "answers": [
+                {
+                  "text": "Chris",
+                  "answer_start": 959
+                },
+                {
+                  "text": "Adonna",
+                  "answer_start": 858
+                },
+                {
+                  "text": "Emmy",
+                  "answer_start": 870
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person that Chris tells to go home to be with her family?",
+              "id": "1287d39cdad034b369310c2b5c32b2001106fda0",
+              "answers": [
+                {
+                  "text": "Adonna",
+                  "answer_start": 1802
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person that tells Adonna to go home to her family?",
+              "id": "906c1ff4d31de0913b14d256fb0ab145311b33ac",
+              "answers": [
+                {
+                  "text": "Chris",
+                  "answer_start": 1792
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "My Wedding and Other Secrets",
+      "url": "https://en.wikipedia.org/wiki/My_Wedding_and_Other_Secrets",
+      "paragraphs": [
+        {
+          "context": "A Romeo and Juliet story set in Auckland, New Zealand, Emily Chu is the daughter of traditional Chinese parents, whose only wishes are that she marries a good Chinese boy and becomes a doctor. But life seems to have other ideas for Emily, who dreams of becoming a world-famous director and falls in love with a white boy from university, James Harrison.\nWhen she and James, two kindred nerd spirits fall clumsily into love they must overcome the expectations of her parents. A Kiwi-Asian, Emily considers herself a banana (yellow on the outside, white on the inside), but her father Dr Chu has a different perspective, and his past threats of disownment on her sister hangs over Emily's head. With their secret marriage, Emily's documentary, and James' ultimatum to learn Mandarin or lose Emily, life suddenly becomes very busy for the young pair.\nEmily is faced with the difficult decision of having to choose between long-suffering James and her parents who have made countless sacrifices to bring their family to New Zealand. It seems Emily must learn the hard way that love and family require sacrifice and not everybody can be happy.",
+          "context_id": "5ac2772b4c89888cc3f6f1e26abe129740e89e9e",
+          "qas": [
+            {
+              "question": "What is the first name of the person who wants to become a director? ",
+              "id": "2a1b187e8fa07557926b6a5d805289eebbdbd142",
+              "answers": [
+                {
+                  "text": "Emily",
+                  "answer_start": 55
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who falls in love with James? ",
+              "id": "63e7be97b32cefbf0e7d63f8c7d86fd763052e05",
+              "answers": [
+                {
+                  "text": "Emily",
+                  "answer_start": 232
+                }
+              ]
+            },
+            {
+              "question": "What are the first names of the people who life got very busy for? ",
+              "id": "d45ac51c3c8f81193f95fbbcd688ece426e6c9b0",
+              "answers": [
+                {
+                  "text": "Emily",
+                  "answer_start": 55
+                },
+                {
+                  "text": "James",
+                  "answer_start": 338
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person who falls in love with James?",
+              "id": "68e1310b440c48082bb4f82b5f2f824cdc859d68",
+              "answers": [
+                {
+                  "text": "Emily Chu",
+                  "answer_start": 55
+                }
+              ]
+            },
+            {
+              "question": "What are the full names of the people who must overcome the expectations of one of their parents?",
+              "id": "35cb136f8661a96b186978d8e6a98cf12e2cbc01",
+              "answers": [
+                {
+                  "text": "Emily Chu",
+                  "answer_start": 55
+                },
+                {
+                  "text": "James Harrison",
+                  "answer_start": 338
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person whose father has a different perspective of her heritage?",
+              "id": "adcd36142d33dbd35f7ffdf6c72e522c97a5342e",
+              "answers": [
+                {
+                  "text": "Emily Chu",
+                  "answer_start": 55
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Crowded Sky",
+      "url": "https://en.wikipedia.org/wiki/The_Crowded_Sky",
+      "paragraphs": [
+        {
+          "context": "A U.S. Navy Lockheed TV-2 jet piloted by Captain Dale Heath, with an enlisted man as a passenger, runs into trouble as soon as it is in the air. Both Heath's radio and his navigation system become disabled, with no way to correctly determine their altitude. At the same time, a Douglas DC-7 airliner piloted by veteran Dick Barnett, is carrying a full load of passengers, each with their own worries and problems to deal with.\nBoth Barnett and Heath have their personal crises, including Heath's unhappy marriage to an unfaithful wife and Barnett's long-time conflict with his co-pilot, Mike Rule, who has his own demons, including his relationship with his father and an affair with head stewardess Kitty Foster.\nBoth aircraft, through various errors in their flight path, are on a collision course that air traffic controllers on the ground are unable to avert. When the crash occurs, Heath sacrifices himself and his passenger, making amends for a past tragedy he had caused. The airliner is badly damaged with Louis Capelli, the flight engineer, being blown out of the aircraft to his death, and the rest of the passengers and crew fighting for their lives. Even with one engine destroyed and a wing on fire, Barnett brings the airliner down safely, but accepts responsibility for the collision during the accident investigation. In the aftermath of the crash, Mike and Kitty are not only survivors but are also planning a future life together.",
+          "context_id": "f16a6213c9a84139dea694018c53fdc762333c50",
+          "qas": [
+            {
+              "question": "What is the first name of the person that has a difficult relationship with his father?",
+              "id": "9cc6e2e0f9b1f994cf025b1f973fa535e8ad0ed6",
+              "answers": [
+                {
+                  "text": "Mike",
+                  "answer_start": 587
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person that has an affair with Kitty Foster?",
+              "id": "9142adb3c968c2ed8937b0f0ff87904930bb35d7",
+              "answers": [
+                {
+                  "text": "Mike Rule",
+                  "answer_start": 587
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Fr\u00e9d\u00e9ric Chopin",
+      "url": "https://en.wikipedia.org/wiki/Fr%C3%A9d%C3%A9ric_Chopin",
+      "paragraphs": [
+        {
+          "context": "Fr\u00e9d\u00e9ric Fran\u00e7ois Chopin (; French: [\u0283\u0254p\u025b\u0303]; Polish: [\u02c8\u0282\u0254p\u025bn]; 1 March 1810 \u2013 17 October 1849) was a Polish composer and virtuoso pianist of the Romantic era who wrote primarily for solo piano. He has maintained worldwide renown as a leading musician of his era, one whose \"poetic genius was based on a professional technique that was without equal in his generation.\"Chopin was born Fryderyk Franciszek Chopin in the Duchy of Warsaw and grew up in Warsaw, which in 1815 became part of Congress Poland. A child prodigy, he completed his musical education and composed his earlier works in Warsaw before leaving Poland at the age of 20, less than a month before the outbreak of the November 1830 Uprising. At 21, he settled in Paris. Thereafter\u2014in the last 18 years of his life\u2014he gave only 30 public performances, preferring the more intimate atmosphere of the salon. He supported himself by selling his compositions and by giving piano lessons, for which he was in high demand. Chopin formed a friendship with Franz Liszt and was admired by many of his other musical contemporaries (including Robert Schumann). In 1835, Chopin obtained French citizenship. After a failed engagement to Maria Wodzi\u0144ska from 1836 to 1837, he maintained an often troubled relationship with the French writer Amantine Dupin (known by her pen name, George Sand). A brief and unhappy visit to Majorca with Sand in 1838\u201339 would prove one of his most productive periods of composition. In his final years, he was supported financially by his admirer Jane Stirling, who also arranged for him to visit Scotland in 1848. For most of his life, Chopin was in poor health. He died in Paris in 1849 at the age of 39, probably of pericarditis aggravated by tuberculosis.\nAll of Chopin's compositions include the piano. Most are for solo piano, though he also wrote two piano concertos, a few chamber pieces, and some 19 songs set to Polish lyrics. His piano writing was technically demanding and expanded the limits of the instrument: his own performances were noted for their nuance and sensitivity. Chopin invented the concept of the instrumental ballade. His major piano works also include mazurkas, waltzes, nocturnes, polonaises, \u00e9tudes, impromptus, scherzos, preludes and sonatas, some published only posthumously. Among the influences on his style of composition were Polish folk music, the classical tradition of J.S. Bach, Mozart, and Schubert, and the atmosphere of the Paris salons of which he was a frequent guest. His innovations in style, harmony, and musical form, and his association of music with nationalism, were influential throughout and after the late Romantic period.\nChopin's music, his status as one of music's earliest superstars, his (indirect) association with political insurrection, his high-profile love-life, and his early death have made him a leading symbol of the Romantic era. His works remain popular, and he has been the subject of numerous films and biographies of varying historical fidelity.",
+          "context_id": "b62c3a66dae9a76273e01abcd927f410d9665742",
+          "qas": [
+            {
+              "question": "What influenced Chopin's style of composition?",
+              "id": "5b603bb3837d2624014b6334ef90f3aa23a79229",
+              "answers": [
+                {
+                  "text": "Polish folk music",
+                  "answer_start": 2344
+                },
+                {
+                  "text": "J.S. Bach",
+                  "answer_start": 2390
+                },
+                {
+                  "text": "Mozart",
+                  "answer_start": 2401
+                },
+                {
+                  "text": "Schubert",
+                  "answer_start": 2413
+                },
+                {
+                  "text": "atmosphere of the Paris salons",
+                  "answer_start": 2431
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who gave only 30 public performances in the last 18 years of his life?",
+              "id": "9af574c5edcd1d446737189ca94b13f613919f20",
+              "answers": [
+                {
+                  "text": "Chopin",
+                  "answer_start": 368
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who maintained an often trouble relationship with the French writer Amantine Dupin?",
+              "id": "48433445f26621a27d837153942e7352b69afb33",
+              "answers": [
+                {
+                  "text": "Chopin",
+                  "answer_start": 1121
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who was supported financially by his admirer Jane Stirling in his final years?",
+              "id": "5db446f71576b4038a27dcda5a7f6d6ef72852f0",
+              "answers": [
+                {
+                  "text": "Chopin",
+                  "answer_start": 1121
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who obtained French citizenship?",
+              "id": "f413c3073b8cfc4ff4f2c8acc732d6a256b505bd",
+              "answers": [
+                {
+                  "text": "Fr\u00e9d\u00e9ric",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who was in poor health for most of his life? ",
+              "id": "46bff0ae1045633b73e35981f10e9e2721f4221a",
+              "answers": [
+                {
+                  "text": "Fr\u00e9d\u00e9ric",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the first name of the person who invented the concept of the instrumental ballade?",
+              "id": "3939f89d2fe44e59c9fd2102fb438d89ed78c586",
+              "answers": [
+                {
+                  "text": "Fr\u00e9d\u00e9ric",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the man who had a failed engagement?",
+              "id": "b94774eef02158d466b104995b7e3bc5fa3fe1b4",
+              "answers": [
+                {
+                  "text": "Fr\u00e9d\u00e9ric Fran\u00e7ois Chopin",
+                  "answer_start": 0
+                }
+              ]
+            },
+            {
+              "question": "What is the real name of the person who brief and unhappy visit to Majorca with Chopin? ",
+              "id": "1822406dbd9f091faa9ea88afccf297bb10b5160",
+              "answers": [
+                {
+                  "text": "Amantine Dupin",
+                  "answer_start": 1289
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person that was admired by Robert Schumann?",
+              "id": "71e135e080edcf5a92bfb42dd492d37cb184cdfe",
+              "answers": [
+                {
+                  "text": "Fr\u00e9d\u00e9ric Fran\u00e7ois Chopin",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "Fryderyk Chopin was born in \u017belazowa Wola, 46 kilometres (29 miles) west of Warsaw, in what was then the Duchy of Warsaw, a Polish state established by Napoleon. The parish baptismal record gives his birthday as 22 February 1810, and cites his given names in the Latin form Fridericus Franciscus (in Polish, he was Fryderyk Franciszek). However, the composer and his family used the birthdate 1 March, which is now generally accepted as the correct date.\n   Fryderyk's father, Nicolas Chopin, was a Frenchman from Lorraine who had emigrated to Poland in 1787 at the age of sixteen. Nicolas tutored children of the Polish aristocracy, and in 1806 married Tekla Justyna Krzy\u017canowska, a poor relative of the Skarbeks, one of the families for whom he worked. Fryderyk was baptized on Easter Sunday, 23 April 1810, in the same church where his parents had married, in Broch\u00f3w. His eighteen-year-old godfather, for whom he was named, was Fryderyk Skarbek, a pupil of Nicolas Chopin. Fryderyk was the couple's second child and only son; he had an elder sister, Ludwika (1807\u20131855), and two younger sisters, Izabela (1811\u20131881) and Emilia (1812\u20131827). Nicolas was devoted to his adopted homeland, and insisted on the use of the Polish language in the household.In October 1810, six months after Fryderyk's birth, the family moved to Warsaw, where his father acquired a post teaching French at the Warsaw Lyceum, then housed in the Saxon Palace. Fryderyk lived with his family in the Palace grounds.  The father played the flute and violin; the mother played the piano and gave lessons to boys in the boarding house that the Chopins kept.  Chopin was of slight build, and even in early childhood was prone to illnesses.Fryderyk may have had some piano instruction from his mother, but his first professional music tutor, from 1816 to 1821, was the Czech pianist Wojciech \u017bywny. His elder sister Ludwika also took lessons from \u017bywny, and occasionally played duets with her brother. It quickly became apparent that he was a child prodigy. By the age of seven Fryderyk had begun giving public concerts, and in 1817 he composed two polonaises, in G minor and B-flat major.  His next work, a polonaise in A-flat major of 1821, dedicated to \u017bywny, is his earliest surviving musical manuscript.In 1817 the Saxon Palace was requisitioned by Warsaw's Russian governor for military use, and the Warsaw Lyceum was reestablished in the Kazimierz Palace (today the rectorate of Warsaw University). Fryderyk and his family moved to a building, which still survives, adjacent to the Kazimierz Palace. During this period, Fryderyk was sometimes invited to the Belweder Palace as playmate to the son of the ruler of Russian Poland, Grand Duke Constantine Pavlovich of Russia; he played the piano for Constantine Pavlovich and composed a march for him. Julian Ursyn Niemcewicz, in his dramatic eclogue, \"Nasze Przebiegi\" (\"Our Discourses\", 1818), attested to \"little Chopin's\" popularity.",
+          "context_id": "c2f31264f686b197edb40cb4473243ef89a64a0c",
+          "qas": [
+            {
+              "question": "What was the actual birthdate for Fryderyk Chopin?",
+              "id": "93abf5f0d4bae666a4f60f984ca1ddebec92625d",
+              "answers": [
+                {
+                  "text": "22 February 1810",
+                  "answer_start": 211
+                }
+              ]
+            },
+            {
+              "question": "What city was Fryderyk Chopin baptitized?",
+              "id": "0f8c5e38503e4d95ce25a582d252da583057ff4d",
+              "answers": [
+                {
+                  "text": "Broch\u00f3w",
+                  "answer_start": 863
+                }
+              ]
+            },
+            {
+              "question": "What was the full name of the person Fryderyk Skarbek was the godfather of?",
+              "id": "c4fe5c8b676af81fbc864b72a7d6a33f7707b589",
+              "answers": [
+                {
+                  "text": "Fryderyk Chopin",
+                  "answer_start": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "context": "In September 1828 Chopin, while still a student, visited Berlin with a family friend, zoologist Feliks Jarocki, enjoying operas directed by Gaspare Spontini and attending concerts by Carl Friedrich Zelter, Felix Mendelssohn and other celebrities. On an 1829 return trip to Berlin, he was a guest of Prince Antoni Radziwi\u0142\u0142, governor of the Grand Duchy of Posen\u2014himself an accomplished composer and aspiring cellist. For the prince and his pianist daughter Wanda, he composed his Introduction and Polonaise brillante in C major for cello and piano, Op. 3.Back in Warsaw that year, Chopin heard Niccol\u00f2 Paganini play the violin, and composed a set of variations, Souvenir de Paganini. It may have been this experience which encouraged him to commence writing his first \u00c9tudes, (1829\u201332), exploring the capacities of his own instrument. On 11 August, three weeks after completing his studies at the Warsaw Conservatory, he made his debut in Vienna. He gave two piano concerts and received many favourable reviews\u2014in addition to some commenting (in Chopin's own words) that he was \"too delicate for those accustomed to the piano-bashing of local artists\". In one of these concerts, he premiered his Variations on L\u00e0 ci darem la mano, Op. 2 (variations on a duet from Mozart's opera Don Giovanni) for piano and orchestra. He returned to Warsaw in September 1829, where he premiered his Piano Concerto No. 2 in F minor, Op. 21 on 17 March 1830.Chopin's successes as a composer and performer opened the door to western Europe for him, and on 2 November 1830, he set out, in the words of Zdzis\u0142aw Jachimecki, \"into the wide world, with no very clearly defined aim, forever.\" With Woyciechowski, he headed for Austria again, intending to go on to Italy. Later that month, in Warsaw, the November 1830 Uprising broke out, and Woyciechowski returned to Poland to enlist. Chopin, now alone in Vienna, was nostalgic for his homeland, and wrote to a friend, \"I curse the moment of my departure.\" When in September 1831 he learned, while travelling from Vienna to Paris, that the uprising had been crushed, he expressed his anguish in the pages of his private journal: \"Oh God! ... You are there, and yet you do not take vengeance!\" Jachimecki ascribes to these events the composer's maturing \"into an inspired national bard who intuited the past, present and future of his native Poland.\"",
+          "context_id": "d054aeb4523249f9930acafa9dafc27d9e0deaca",
+          "qas": [
+            {
+              "question": "What is the name of the person that was a guest of the governor of the Grand Duchy of Posen?",
+              "id": "c3f95475b0b863ba0bdbe9f707032de9d02572fe",
+              "answers": [
+                {
+                  "text": "Chopin",
+                  "answer_start": 18
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person that composed the Introduction and Polonaise brillante in C major for cello and piano, Op. 3",
+              "id": "6107b5cb1156cb81ac42d540c19f3f353d5017b4",
+              "answers": [
+                {
+                  "text": "Chopin",
+                  "answer_start": 18
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person Chopin left with on 2 November 1830?",
+              "id": "a7096662408991ad0880902536e7f15e44f3bc45",
+              "answers": [
+                {
+                  "text": "Woyciechowski",
+                  "answer_start": 1672
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who was a guest of Prince Antoni Radziwi\u0142\u0142?",
+              "id": "5644ad2c478ee895544ced7acb2c64d132e54e83",
+              "answers": [
+                {
+                  "text": "Chopin",
+                  "answer_start": 18
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who composed a set of variations, Souvenir de Paganini?",
+              "id": "3e2c071392499bcf869e7a93cdb3462e0346ac7c",
+              "answers": [
+                {
+                  "text": "Chopin",
+                  "answer_start": 580
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who was encouraged to commence writing his first \u00c9tudes?",
+              "id": "9276ed643f536dc79986cec1b8effd0e27e8e541",
+              "answers": [
+                {
+                  "text": "Chopin",
+                  "answer_start": 580
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who made his debut in Vienna?",
+              "id": "d38f81414534c19599f280d3cd10e96f7197e135",
+              "answers": [
+                {
+                  "text": "Chopin",
+                  "answer_start": 580
+                }
+              ]
+            },
+            {
+              "question": "What is the last name of the person who premiered his Variations on L\u00e0 ci darem la mano, Op. 2 for piano and orchestra?",
+              "id": "290cea3da05a72dc83b3d78fc906d5a1c6f9212f",
+              "answers": [
+                {
+                  "text": "Chopin",
+                  "answer_start": 580
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "To Be Fat like Me",
+      "url": "https://en.wikipedia.org/wiki/To_Be_Fat_like_Me",
+      "paragraphs": [
+        {
+          "context": "Pretty, popular and athletic Aly has been banking on a softball scholarship as her ticket to college. She has an active life and never seems to sit still. When she injures her knee, she realizes that she will have to fund her education in other ways. She resents her mother because a few years ago, her mother became ill as a consequence of binge eating and used the money from her daughter's college fund in order to pay her hospital bill. Aly is overly critical of her family's high-fat diet. She even refuses to eat a cake that her mother purchased for her.\nAly enters a documentary film contest in hopes of using the prize money in order to fund her further education. Convinced that her overweight younger brother and mother use their struggles with weight as an excuse for everything wrong in their lives, Aly decides to take a summer course wearing a fat suit and hidden camera to prove personality can outshine physical appearance. Aly soon realizes how difficult the life can be for the overweight, as she is shunned by other students, despite her resolve to be kind and maintain the same personality she always had. She meets Ramona, an overweight girl in the same class who shares aspects of her personal life with Aly but feels betrayed when Aly uses this material in her documentary. Aly titles her documentary Fat Like Me, a reference to John Howard Griffin's 1961 book Black Like Me, which recounts Griffin's experience living as an African-American in the segregated Southern United States for several weeks after receiving skin-darkening injections.",
+          "context_id": "9f71f1e29735587fc4d7f9f9f0ec0e3952db5e5d",
+          "qas": [
+            {
+              "question": "Who meets an overweight girl in the same class?",
+              "id": "7f36197da0617efc811a32edb0caaadf8ff551a3",
+              "answers": [
+                {
+                  "text": "Aly",
+                  "answer_start": 940
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "The Wood",
+      "url": "https://en.wikipedia.org/wiki/The_Wood",
+      "paragraphs": [
+        {
+          "context": "Roland is getting married (and is currently missing) and Slim, who scoffs at the idea of marriage, is furious at Roland for disappearing. The story reminisces back to Mike's (Omar Epps, portrayed as a youth by Sean Nelson) first encounters with Roland and Slim, his first real crush on a girl named Alicia, and the three young men's misadventures as teenagers growing up in 1980s Inglewood, California (\"The Wood\").  Shy and awkward, Mike sticks out like a sore thumb on his first day, but is quickly befriended by Slim and Roland.\nOn a dare from Slim and Roland, Mike reluctantly runs and grabs Alicia's butt, leading to a big fight with her big brother Stacey, a Blood gang member. While he is thoroughly beat down, Mike earns Stacey's private respect for fighting back like a man.  Meanwhile in present day, Mike and Slim go to find Roland for his wedding, when they get a call from Tanya saying that she has him with her and that he is very drunk. They go to her house to pick him up to take him back to the wedding to marry his bride Lisa because they only have two hours before the ceremony begins.\nBack to their old school times: on their way to their first dance of the year, the boys go to a store that gets held up by Stacey, who recognizes the boys and offers them a ride to the dance. The boys almost get arrested by two cops due to Stacey's broken taillight. Mike's quick thinking prevents one of the cops from finding Stacey's gun and they are let go not realizing that the hold-up Stacey and Boo did is what gotten them off the hook. Impressed, Stacey begins a new friendship with Mike by apologizing for their prior run-in. However, he explains that he was protecting his sister, and, seeing how much Mike likes her, gives him advice on how to win her heart.  ",
+          "context_id": "3a11aa4230d1eb539c503dcfa3120e5540c0c7e8",
+          "qas": [
+            {
+              "question": "Who is beaten up?",
+              "id": "e02c89916621b3233c68e99052ceddc576a87e4b",
+              "answers": [
+                {
+                  "text": "Mike",
+                  "answer_start": 718
+                }
+              ]
+            },
+            {
+              "question": "Who is very drunk at a wedding?",
+              "id": "518bcb4f3318ba1a1dd91c2ed1f57dee25975ff2",
+              "answers": [
+                {
+                  "text": "Roland",
+                  "answer_start": 836
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Amchitka 1",
+      "url": "https://en.wikipedia.org/wiki/Amchitka",
+      "paragraphs": [
+        {
+          "context": "A few days after the Milrow test, the Don't Make A Wave Committee was organized at a meeting in Vancouver, British Columbia, Canada. The Committee's name referred to predictions made by a Vancouver journalist named Bob Hunter, later to become Greenpeace member 000. He wrote that the test would cause earthquakes and a tsunami. On the agenda was whether to fight another blast at the island, or whether to expand their efforts to fight all perceived threats against the environment. As he was leaving, one man gave the traditional farewell of the peace-activist movement, \"Peace.\" \"Make it a green peace,\" replied another member. The Committee would later become Greenpeace.The AEC considered the likelihood of the test triggering a severe earthquake \"very unlikely\", unless one was already imminent on a nearby fault, and considered a tsunami \"even more unlikely\". Others disagreed. Russell Train, then Chairman of the Council on Environmental Quality, argued that \"experience with Milrow ... does not provide a sure basis for extrapolation. In the highly nonlinear phenomena involved in earthquake generation, there may be a threshold value of the strain that must be exceeded prior to initiation of a large earthquake. ... The underground explosion could serve as the first domino of the row of dominoes leading to a major earthquake. ... as in the case of earthquakes it is not possible at this time to assess quantitatively the probability of a tsunami following the explosion.\"\nIn July 1971, a group called the Committee for Nuclear Responsibility filed suit against the AEC, asking the court to stop the test. The suit was unsuccessful, with the Supreme Court denying the injunction by 4 votes to 3, and Richard Nixon personally authorized the $200 million test, in spite of objections from Japan, Peru, and Sweden. \"What the Court didn't know, however, was that six federal agencies, including the departments of State and Interior, and the fledgling EPA, had lodged serious objections to the Cannikin test, ranging from environmental and health concerns to legal and diplomatic problems. Nixon issued an executive order to keep the comments from being released.\" The Don't Make A Wave Committee chartered a boat, in which they had intended to sail to the island in protest, but due to weather conditions they were unable to reach their destination.",
+          "context_id": "ede8a6beeb360985d662551d41254ec2ad1d2fa6",
+          "qas": [
+            {
+              "question": "What was the original name of Greenpeace?",
+              "id": "04c3714e5b76d4944d775daf586a833fa85441fb",
+              "answers": [
+                {
+                  "text": "Don't Make A Wave Committee",
+                  "answer_start": 37
+                }
+              ]
+            },
+            {
+              "question": "What is the name of the person that thought the explosion could cause a domino effect leading to a major earthquake?",
+              "id": "12abf01da33a903703b02566af4f0a6d0f9eca10",
+              "answers": [
+                {
+                  "text": "Russell Train",
+                  "answer_start": 884
+                }
+              ]
+            },
+            {
+              "question": "What is the full name of the person who argued that \"the underground explosion could serve as the first domino of the row of dominoes leading to a major earthquake\"?",
+              "id": "deb251915ba7f8bcea326275caad5bc8f778d883",
+              "answers": [
+                {
+                  "text": "Russell Train",
+                  "answer_start": 884
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The original data file I uploaded here did not contain the subset of original questions. It only had the perturbed data. The PR adds a separate fil with the original instances, and updates the README accordingly.