### PR TITLE
fix example that was not fully altered

### DIFF
--- a/UD_English/en_combo-ud-test.altered_only.verb-to-noun.conllu
+++ b/UD_English/en_combo-ud-test.altered_only.verb-to-noun.conllu
@@ -1512,7 +1512,7 @@
 7	moment	moment	NOUN	SG-NOM	Number=Sing	2	obl	_	_
 8	with	with	ADP	_	_	10	case	_	_
 9	no	no	ADJ	ING	Degree=Pos	10	amod	_	_
-10	eyes	eye	NOUN	PL-NOM	Number=Plur	2	obl	_	SpaceAfter=No
+10	end	end	NOUN	SG-NOM	Number=Sing	7	nmod	_	SpaceAfter=No
 11	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 4131***


### PR DESCRIPTION
One of the verb-to-noun altered examples had an incorrect altered form. This caused an error when running stats.py, as no altered adposition was found for the sentence in question. This commit updates the conllu file with the correct attachment and other metadata.